### PR TITLE
slackclient version 1.0 support

### DIFF
--- a/spidermon/contrib/actions/slack/__init__.py
+++ b/spidermon/contrib/actions/slack/__init__.py
@@ -71,7 +71,10 @@ class SlackMessageManager():
         ])
 
     def _api_call(self, method, **kwargs):
-        return json.loads(self._client.api_call(method, **kwargs))
+        response = self._client.api_call(method, **kwargs)
+        if isinstance(response, basestring):  # slackclient < v1.0
+            response = json.loads(response)
+        return response
 
     def _get_user_channel(self, user_id):
         return self._api_call('im.open', user=user_id)['channel']['id']


### PR DESCRIPTION
I accidently installed `slackclient` v1.0 instead of 0.15 specified in the requirements file and I broke the monitor.
However it seems the reason for that was pretty much one line of code. In versions 0.15 `api_call` returns string response when any version beyond that it returns dict object (it loads in json with `json.loads()` before returning the same string).

Are there any other reasons why we would run v0.15 rather than v1.0 ?
