### PR TITLE
[WIP] Merge validation requirements into main file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ six==1.9.0
 Jinja2==2.7.3
 slackclient==1.0.0
 boto==2.39.0
+jsonschema==2.5.1
+schematics==1.0.4
+python-slugify==1.2.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,3 @@
 -r ../requirements.txt
--r validation.txt
 pytest>=2.7.0
 Scrapy

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -1,4 +1,0 @@
-jsonschema==2.4.0
-schematics==1.0.4
-python-slugify==1.0.2
-strict-rfc3339==0.6


### PR DESCRIPTION
- from validation requirements was removed `strict-rfc3339` (didn't find any imports for it)
- versions of others was updated if it was possible (tested compatibility with tests)
- validation requirements were merged into main file
