### PR TITLE
add premailer to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ six>=1.9.0
 Jinja2==2.7.3
 slackclient==1.0.0
 boto==2.39.0
+premailer==2.9.2


### PR DESCRIPTION
`premailer` is missing from requirements and `python setup.py test` fails.