### PR TITLE
Move all requirements into `setup.py`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,8 @@ Pip:
 
 Pipenv (recommended):
 
-    pipenv install git+https://github.com/scrapinghub/spidermon.git#egg=spidermon
+    pipenv install "git+https://github.com/scrapinghub/spidermon.git#egg=spidermon[validation]"
+
 
 
 ## Using Spidermon in your project

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-six>=1.9.0
-Jinja2==2.7.3
-slackclient==1.0.0
-boto==2.39.0
-premailer==2.9.2
+# Get requirements from setup.py
+.

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,2 @@
--r ../requirements.txt
-sphinx>=1.2.3
-sphinx-rtd-theme>=0.1.6
-s3cmd>=1.5.2
+# Get requirements from setup.py
+.[docs]

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,2 @@
--r ../requirements.txt
--r validation.txt
-pytest>=2.7.0
-Scrapy
+# Get requirements from setup.py
+.[validation,tests]

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -1,4 +1,2 @@
-jsonschema==2.6.0
-schematics==2.0.1
-python-slugify==1.0.2
-strict-rfc3339==0.6
+# Get requirements from setup.py
+.[validation]

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,43 @@
 from setuptools import setup, find_packages
 
+REQUIREMENTS = [
+    "six>=1.9.0",
+    "Jinja2==2.7.3",
+    "slackclient==1.0.0",
+    "boto==2.39.0",
+    "premailer==2.9.2",
+]
+
+TESTS_REQUIRE = [
+    "pytest>=2.7.0",
+    "Scrapy"
+]
+
+VALIDATION_REQUIRE = [
+    "jsonschema==2.6.0",
+    "schematics==2.0.1",
+    "python-slugify==1.0.2",
+    "strict-rfc3339==0.6",
+]
+
+DOCS_REQUIRE = [
+    "sphinx>=1.2.3",
+    "sphinx-rtd-theme>=0.1.6",
+    "s3cmd>=1.5.2"
+]
+
 setup(
     name='spidermon',
     version='1.3.0',
     packages=find_packages(),
-    package_data={'spidermon': ['VERSION']},
+    package_data={"spidermon": ["VERSION"]},
     zip_safe=False,
     include_package_data=True,
-    install_requires=[
-        'six>=1.9.0',
-    ],
-    tests_require=[
-        'six>=1.9.0',
-        "pytest>=2.7.0",
-    ],
+    install_requires=REQUIREMENTS,
+    tests_require=TESTS_REQUIRE + VALIDATION_REQUIRE,
     extras_require={
-        'validation':  [
-            'jsonschema',
-            'schematics',
-            'python-slugify',
-            'strict-rfc3339'
-        ],
-    }
+        "validation": VALIDATION_REQUIRE,
+        "docs": DOCS_REQUIRE,
+        "tests": TESTS_REQUIRE
+    },
 )


### PR DESCRIPTION
Greetings!

I am a new guy here in Shub :spider:  and I was trying out spidermon, but I had some trouble while installing it.
I tried recommended way to install it (`pipenv install pip+https://gitbub...`), but it doesn't get all requirements (eg. schematics). Then I realized that the *validation* requirements aren't installed by using the recommended way.
In this PR I moved all requirements into `setup.py`. I kept the `.txt` files for compatibility, but removed the requirements from them for DRYness.

I'd love some feedback.