### PR TITLE
Fix getting started example (AttributeError: 'ItemCountMonitor' object has no attribute 'stats')

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -94,8 +94,7 @@ your monitors.
 
         @monitors.name('Minimum number of items')
         def test_minimum_number_of_items(self):
-            item_extracted = getattr(
-                self.stats, 'item_scraped_count', 0)
+            item_extracted = self.data.stats.get('item_scraped_count', 0)
             minimum_threshold = 10
 
             msg = 'Extracted less than {} items'.format(

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -94,7 +94,8 @@ your monitors.
 
         @monitors.name('Minimum number of items')
         def test_minimum_number_of_items(self):
-            item_extracted = self.data.stats.get('item_scraped_count', 0)
+            item_extracted = getattr(
+                self.stats, 'item_scraped_count', 0)
             minimum_threshold = 10
 
             msg = 'Extracted less than {} items'.format(
@@ -330,12 +331,12 @@ a failure when we have a item validation error:
     # (...other monitors...)
 
     @monitors.name('Item validation')
-    class ItemValidationMonitor(Monitor):
+    class ItemValidationMonitor(Monitor, StatsMonitorMixin):
 
         @monitors.name('No item validation errors')
         def test_no_item_validation_errors(self):
             validation_errors = getattr(
-                self.data.stats, 'spidermon/validation/fields/errors', 0
+                self.stats, 'spidermon/validation/fields/errors', 0
             )
             self.assertEqual(
                 validation_errors,


### PR DESCRIPTION
When running the first monitor example from the Getting Started chapter, users would eventually get an error such as:

```
AttributeError: 'ItemCountMonitor' object has no attribute 'stats'
```

Arguably this could be fixed by replacing `self.stats` by `self.data.stats` or by using the `StatsMonitorMixin`. As this is a getting started section, this commit opted for the simpler solution (less objects to import, more explicit API).