### PR TITLE
Suggest PyPI as recommended installation source

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -14,4 +14,4 @@ The recommended way to install the library is by adding the additional
 
 .. code-block:: bash
 
-    pip install git+ssh://git@github.com/scrapinghub/spidermon.git#egg=spidermon[monitoring,validation]
+    pip install "spidermon[monitoring,validation]"


### PR DESCRIPTION
Suggest a stable PyPI release as default installation source instead of the git repo.