### PR TITLE
Fix problem caused by backward incompatible change in jsonschema 3.0.0

### DIFF
--- a/docs/source/item-validation.rst
+++ b/docs/source/item-validation.rst
@@ -27,6 +27,10 @@ Schematics_ is a validation library based on ORM-like models. These models inclu
 some common data types and validators, but they can also be extended to define
 custom validation rules.
 
+.. warning::
+
+   You need to install `schematics`_ to use this feature.
+
 .. code-block:: python
 
     # Usually placed in validators.py file
@@ -59,7 +63,7 @@ an example of a schema for the quotes item from the :doc:`tutorial </getting-sta
 .. code-block:: json
 
   {
-    "$schema": "http://json-schema.org/draft-04/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
     "properties": {
       "quote": {
@@ -82,13 +86,6 @@ an example of a schema for the quotes item from the :doc:`tutorial </getting-sta
       "author_url"
     ]
   }
-
-.. warning::
-
-   Stable version of `jsonschema`_ supports only **draft-3** and **draft-4**. You can
-   use `version 3.0.0`_ (still in beta) for **draft-6** and **draft-7**. It should
-   work without any change in your validators code, but it is not fully supported
-   by spidermon yet.
 
 Settings
 --------

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Jinja2==2.7.3
 slackclient==1.0.0
 boto==2.39.0
 premailer==2.9.2
-jsonschema==2.6.0
+jsonschema==3.0.0
 schematics==2.1.0
 python-slugify==1.0.2
 strict-rfc3339==0.6

--- a/tests/test_validators_jsonschema.py
+++ b/tests/test_validators_jsonschema.py
@@ -825,8 +825,19 @@ class MaxProperties(SchemaTest):
 
 
 class Maximum(SchemaTest):
+    # exclusiveMaximum behaviour changed from draft-04 to draft-06
+    # http://json-schema.org/draft-06/json-schema-release-notes.html#backwards-incompatible-changes
     schema = {"maximum": 3.0}
-    schema_exclusive = {"maximum": 3.0, "exclusiveMaximum": True}
+    draft4_schema_exclusive = {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "maximum": 3.0,
+        "exclusiveMaximum": True,
+    }
+    draft6_schema_exclusive = {
+        "$schema": "http://json-schema.org/draft-06/schema",
+        "exclusiveMaximum": 3.0,
+    }
+
     data_tests = [
         DataTest(name="below", data=2.6, valid=True),
         DataTest(
@@ -839,18 +850,41 @@ class Maximum(SchemaTest):
             name="ignores non-numbers", data={"foo": 1, "bar": 2, "baz": 3}, valid=True
         ),
         DataTest(
-            name="exclusive. below", schema=schema_exclusive, data=2.2, valid=True
+            name="draft4 exclusive. below",
+            schema=draft4_schema_exclusive,
+            data=2.2,
+            valid=True,
         ),
         DataTest(
-            name="exclusive. boundary point",
-            schema=schema_exclusive,
+            name="draft4_exclusive. boundary point",
+            schema=draft4_schema_exclusive,
             data=3.0,
             valid=False,
             expected_errors={"": [messages.NUMBER_TOO_HIGH]},
         ),
         DataTest(
-            name="exclusive. above",
-            schema=schema_exclusive,
+            name="draft4_exclusive. above",
+            schema=draft4_schema_exclusive,
+            data=3.5,
+            valid=False,
+            expected_errors={"": [messages.NUMBER_TOO_HIGH]},
+        ),
+        DataTest(
+            name="draft6 exclusive. below",
+            schema=draft6_schema_exclusive,
+            data=2.2,
+            valid=True,
+        ),
+        DataTest(
+            name="draft6_exclusive. boundary point",
+            schema=draft6_schema_exclusive,
+            data=3.0,
+            valid=False,
+            expected_errors={"": [messages.NUMBER_TOO_HIGH]},
+        ),
+        DataTest(
+            name="draft6_exclusive. above",
+            schema=draft6_schema_exclusive,
             data=3.5,
             valid=False,
             expected_errors={"": [messages.NUMBER_TOO_HIGH]},
@@ -889,8 +923,19 @@ class MinProperties(SchemaTest):
 
 
 class Minimum(SchemaTest):
+    # exclusiveMinimum behaviour changed from draft-04 to draft-06
+    # http://json-schema.org/draft-06/json-schema-release-notes.html#backwards-incompatible-changes
     schema = {"minimum": 1.1}
-    schema_exclusive = {"minimum": 1.1, "exclusiveMinimum": True}
+    draft4_schema_exclusive = {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "minimum": 1.1,
+        "exclusiveMinimum": True,
+    }
+    draft6_schema_exclusive = {
+        "$schema": "http://json-schema.org/draft-06/schema",
+        "exclusiveMinimum": 1.1,
+    }
+
     data_tests = [
         DataTest(name="above", data=2.6, valid=True),
         DataTest(
@@ -901,18 +946,41 @@ class Minimum(SchemaTest):
         ),
         DataTest(name="ignores non-numbers", data="x", valid=True),
         DataTest(
-            name="exclusive. above", schema=schema_exclusive, data=1.2, valid=True
+            name="exclusive. above",
+            schema=draft4_schema_exclusive,
+            data=1.2,
+            valid=True,
         ),
         DataTest(
-            name="exclusive. boundary point",
-            schema=schema_exclusive,
+            name="exclusive. above",
+            schema=draft6_schema_exclusive,
+            data=1.2,
+            valid=True,
+        ),
+        DataTest(
+            name="draft4 exclusive. boundary point",
+            schema=draft4_schema_exclusive,
             data=1.1,
             valid=False,
             expected_errors={"": [messages.NUMBER_TOO_LOW]},
         ),
         DataTest(
-            name="exclusive. below",
-            schema=schema_exclusive,
+            name="draft6 exclusive. boundary point",
+            schema=draft6_schema_exclusive,
+            data=1.1,
+            valid=False,
+            expected_errors={"": [messages.NUMBER_TOO_LOW]},
+        ),
+        DataTest(
+            name="draft4 exclusive. below",
+            schema=draft4_schema_exclusive,
+            data=0.6,
+            valid=False,
+            expected_errors={"": [messages.NUMBER_TOO_LOW]},
+        ),
+        DataTest(
+            name="draft6 exclusive. below",
+            schema=draft6_schema_exclusive,
             data=0.6,
             valid=False,
             expected_errors={"": [messages.NUMBER_TOO_LOW]},


### PR DESCRIPTION
After release of jsonschema 3.0.0, it is possible to validate data against draft6 and draft7. The keywords _exclusiveMinimum_ and _exclusiveMaximum_ changed in a backwards incompatible change which required an update in the existing tests.