### PR TITLE
Add strict-rfc3339 as required dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     package_data={"spidermon": ["VERSION"]},
     zip_safe=False,
     include_package_data=True,
-    install_requires=["jsonschema", "python-slugify", "six>=1.9.0"],
+    install_requires=["jsonschema", "strict-rfc3339", "python-slugify", "six>=1.9.0"],
     tests_require=test_requirements,
     extras_require={
         # Specific monitors and tools to support notifications and reports
@@ -30,7 +30,7 @@ setup(
             "sentry-sdk",
         ],
         # Data validation
-        "validation": ["schematics", "strict-rfc3339"],
+        "validation": ["schematics"],
         # Tools to run the tests
         "tests": test_requirements,
         "pep8": ["black"],


### PR DESCRIPTION
The reason is here #113 

Since it's possible that someone installs spidermon without `validation`, and then enables jsonschema and uses formats from `strict-rfc3339`. These formats validation won't work since `strict-rfc3339` not installed. And because of JSON schema standard you won't see any error too.

But I am not sure about it, jsonschema has `format` extras which we probably need to add here too?