### PR TITLE
Fixed an error with getting stats

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -95,7 +95,7 @@ your monitors.
         @monitors.name('Minimum number of items')
         def test_minimum_number_of_items(self):
             item_extracted = getattr(
-                self.stats, 'item_scraped_count', 0)
+                self.data.stats, 'item_scraped_count', 0)
             minimum_threshold = 10
 
             msg = 'Extracted less than {} items'.format(


### PR DESCRIPTION
Fixed an error:
```
Traceback (most recent call last):
  File "~/Code/quotesbot/quotesbot/monitors.py", line 9, in test_minimum_number_of_items
    self.stats, 'item_scraped_count', 0)
AttributeError: 'ItemCountMonitor' object has no attribute 'stats'
```