### PR TITLE
[+1 MRG] Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     package_data={"spidermon": ["VERSION"]},
     zip_safe=False,
     include_package_data=True,
-    install_requires=["jsonschema", "python-slugify", "six>=1.9.0"],
+    install_requires=["jsonschema[format]", "python-slugify", "six>=1.9.0"],
     tests_require=test_requirements,
     extras_require={
         # Specific monitors and tools to support notifications and reports


### PR DESCRIPTION
I propose to include `format` since it seems an obvious mistake that people use `format` and miss the dependencies.
The problem is if you have `format` validator and lack deps you won't get any error and probably will never know.
Related to #51 