### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,12 +40,10 @@ Install
 
 The quick way::
 
-    pip install spidermon
+    pip install "spidermon[monitoring,validation]"
 
 For more details see the install section in the documentation:
 https://spidermon.readthedocs.io/en/latest/installation.html
-
-For implementing any of Spidermon's amazing features such as `actions <https://spidermon.readthedocs.io/en/latest/actions.html>`_ or `item validations <https://spidermon.readthedocs.io/en/latest/item-validation.html>`_. We recommend to check the documentation for instructions to download specific packages needed for the, to work. 
 
 Documentation
 =============
@@ -56,8 +54,3 @@ Contributing
 ============
 
 Looking forward to improve Spidermon, check out out our `CONTRIBUTING.md <https://github.com/scrapinghub/spidermon/blob/master/CONTRIBUTING.rst>`_.
-
-License
-=======
-
-All source code is under `BSD License <https://github.com/scrapinghub/spidermon/blob/master/LICENSE>`_ 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,6 @@
 =========
 Spidermon
 =========
-The battle tested spider monitoring library made with 💝 by `ScrapingHub <https://blog.scrapinghub.com/spidermon-scrapy-spider-monitoring>`_ is now open-source.
 
 .. image:: https://img.shields.io/travis/scrapinghub/spidermon.svg
     :target: https://travis-ci.org/scrapinghub/spidermon
@@ -46,7 +45,7 @@ The quick way::
 For more details see the install section in the documentation:
 https://spidermon.readthedocs.io/en/latest/installation.html
 
-For implementing any of Spidermon's amazing features such as `actions <https://spidermon.readthedocs.io/en/latest/actions.html>`_ or `item validations <https://spidermon.readthedocs.io/en/latest/item-validation.html>`_. We recommend to check the documentation for instructions to download specific packages needed for the, to work.  
+For implementing any of Spidermon's amazing features such as `actions <https://spidermon.readthedocs.io/en/latest/actions.html>`_ or `item validations <https://spidermon.readthedocs.io/en/latest/item-validation.html>`_. We recommend to check the documentation for instructions to download specific packages needed for the, to work. 
 
 Documentation
 =============
@@ -56,7 +55,7 @@ Documentation is available online at https://spidermon.readthedocs.io/ and in th
 Contributing 
 ============
 
-Looking forward to improve Spidermon, checkout out our awesome `CONTRIBUTING.md <https://github.com/scrapinghub/spidermon/blob/master/CONTRIBUTING.rst>`_ to get you started.
+Looking forward to improve Spidermon, check out out our `CONTRIBUTING.md <https://github.com/scrapinghub/spidermon/blob/master/CONTRIBUTING.rst>`_.
 
 License
 =======

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 =========
 Spidermon
 =========
+The battle tested spider monitoring library made with 💝 by `ScrapingHub <https://blog.scrapinghub.com/spidermon-scrapy-spider-monitoring>`_ is now open-source.
 
 .. image:: https://img.shields.io/travis/scrapinghub/spidermon.svg
     :target: https://travis-ci.org/scrapinghub/spidermon
@@ -45,7 +46,19 @@ The quick way::
 For more details see the install section in the documentation:
 https://spidermon.readthedocs.io/en/latest/installation.html
 
+For implementing any of Spidermon's amazing features such as `actions <https://spidermon.readthedocs.io/en/latest/actions.html>`_ or `item validations <https://spidermon.readthedocs.io/en/latest/item-validation.html>`_. We recommend to check the documentation for instructions to download specific packages needed for the, to work.  
+
 Documentation
 =============
 
 Documentation is available online at https://spidermon.readthedocs.io/ and in the ``docs`` directory.
+
+Contributing 
+============
+
+Looking forward to improve Spidermon, checkout out our awesome `CONTRIBUTING.md <https://github.com/scrapinghub/spidermon/blob/master/CONTRIBUTING.rst>`_ to get you started.
+
+License
+=======
+
+All source code is under `BSD License <https://github.com/scrapinghub/spidermon/blob/master/LICENSE>`_ 


### PR DESCRIPTION
- Add polite warning
- Add a reference to CONTRIBUTING
- ADD License reference

Tried to fix the placement of badges, but couldn't because of rST.

Sidenote
GitHub is not able to render .rst as good as markdown. I say we migrate to markdown. There is no direct advantage but having markdown provide better formatting, support, and placement   