### PR TITLE
email_subject*: don't fail if SPIDERMON_EMAIL_SUBJECT_TEMPLATE is configured in favor of SPIDERMON_EMAIL_SUBJECT

### DIFF
--- a/spidermon/contrib/actions/email/__init__.py
+++ b/spidermon/contrib/actions/email/__init__.py
@@ -59,7 +59,7 @@ class SendEmail(ActionWithTemplates):
             raise NotConfigured(
                 "You must provide at least one recipient for the message."
             )
-        if not self.subject:
+        if not self.subject and not self.subject_template:
             raise NotConfigured("You must provide a subject for the message.")
         if not (
             self.body_text or body_text_template or body_html or self.body_html_template


### PR DESCRIPTION
Allow usage of SPIDERMON_EMAIL_SUBJECT_TEMPLATE instead of SPIDERMON_EMAIL_SUBJECT without failing during initialization. If EMAIL_SUBJECT is configured it still has precedence.