### PR TITLE
Slackclient version problem

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -165,6 +165,17 @@ SPIDERMON_EMAIL_SUBJECT_TEMPLATE
 Slack action
 ============
 
+.. warning::
+
+   You need to install `slackclient`_ to use this feature.
+
+   .. code-block:: shell
+
+     $ pip install "slackclient>=1.3,<2.0"
+
+   **Do not install** a version greater than **1.3.*** because newer versions
+   work only with Python 3.6+ and contain incompatible features.
+
 This action allows you to send custom messages to a `Slack`_ channel (or user)
 using a bot when your monitor suites finishes their execution. To use this action
 you need to provide the `Slack credentials`_ in your `settings.py`
@@ -538,3 +549,5 @@ the `run_action` method.
         def run_action(self):
             # Include here the logic of your action
             # (...)
+
+.. _`slackclient`: https://pypi.org/project/slackclient/

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -165,20 +165,21 @@ SPIDERMON_EMAIL_SUBJECT_TEMPLATE
 Slack action
 ============
 
-.. warning::
-
-   To use this feature you need to install `slackclient`_ **1.3 or higher, but
-   lower than 2.0**. Version 2.0 is Python3.6+ only and contains incompatible
-   features.
-
-   .. code-block:: shell
-
-     $ pip install "slackclient>=1.3,<2.0"
 
 This action allows you to send custom messages to a `Slack`_ channel (or user)
-using a bot when your monitor suites finishes their execution. To use this action
-you need to provide the `Slack credentials`_ in your `settings.py`
-file as follows:
+using a bot when your monitor suites finish their execution.
+
+To use this action you need to:
+
+#.  Install `slackclient`_ 1.3 or higher, but lower than 2.0:
+
+    .. code-block:: shell
+
+        $ pip install "slackclient>=1.3,<2.0"
+
+    .. warning:: This action **does not** work with `slackclient`_ 2.0 or later.
+
+#.  Provide the `Slack credentials`_ in your ``settings.py`` file as follows:
 
 .. code-block:: python
 

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -167,14 +167,13 @@ Slack action
 
 .. warning::
 
-   You need to install `slackclient`_ to use this feature.
+   To use this feature you need to install `slackclient`_ **1.3 or higher, but
+   lower than 2.0**. Version 2.0 is Python3.6+ only and contains incompatible
+   features.
 
    .. code-block:: shell
 
      $ pip install "slackclient>=1.3,<2.0"
-
-   **Do not install** a version greater than **1.3.*** because newer versions
-   work only with Python 3.6+ and contain incompatible features.
 
 This action allows you to send custom messages to a `Slack`_ channel (or user)
 using a bot when your monitor suites finishes their execution. To use this action

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six
 Jinja2
-slackclient
+slackclient>=1.3.0,<2.0.0
 boto
 premailer
 jsonschema[format]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "monitoring": [
             "scrapy",
             "Jinja2",
-            "slackclient",
+            "slackclient>=1.3.0,<2.0.0",
             "boto",
             "premailer",
             "sentry-sdk",


### PR DESCRIPTION
This should fix #158 . As slackclient version 1.3.* still works and the actual version don't work with Python lesser than 3.6, I didn't update the code to use newest version of the library. When spidermon become Python3.6+ only or the library stop working, we will need to change our action.