### PR TITLE
Add import statement in item validation docs

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -328,6 +328,9 @@ a failure when we have a item validation error:
 .. code-block:: python
 
     # monitors.py
+
+    from spidermon.contrib.monitors.mixins import StatsMonitorMixin
+
     # (...other monitors...)
 
     @monitors.name('Item validation')


### PR DESCRIPTION
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>

Import statement for `StatsMonitorMixin` missing in Getting started docs.