### PR TITLE
Require Twisted<=19.2.0 for Python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 from setuptools import setup, find_packages
 
-test_requirements = ["pytest>=2.7.0", "pytest-cov", "pytest-mock", "scrapy"]
+test_requirements = [
+    "pytest>=2.7.0",
+    "pytest-cov",
+    "pytest-mock",
+    "scrapy",
+    'Twisted<=19.2.0;python_version=="3.4"',
+]
 
 setup(
     name="spidermon",


### PR DESCRIPTION
Twisted 19.2.0 is the last Twisted version with Python 3.4 support.