### PR TITLE
docs: Improve stats history documentation

### DIFF
--- a/docs/source/stats-collection.rst
+++ b/docs/source/stats-collection.rst
@@ -70,10 +70,18 @@ returned in the previous spider executions.
     class SpiderCloseMonitorSuite(MonitorSuite):
         monitors = [HistoryMonitor]
 
-.. note::
-    If you are running your spider in `Scrapy Cloud`_ you need to enable the
-    `DotScrapy Persistence Add-on`_ in your project to keep your ``.scrapy`` directory
-    available between job executions.
+.. warning::
+    Running your spider in `Scrapy Cloud`_ requires you to manually change some settings
+    in your project:
 
+    #. Enable `DotScrapy Persistence Add-on`_ in your project to keep your ``.scrapy`` directory
+       available between job executions.
+    #. `STATS_CLASS`_ is overriden by default in `Scrapy Cloud`_. You need to manually include
+       ``spidermon.contrib.stats.statscollectors.LocalStorageStatsHistoryCollector`` in your `spider
+       settings`_. The drawback is that you job stats will not be uploaded to Scrapy Cloud interface
+       and will be available only in the job logs.
+
+.. _`STATS_CLASS`: https://docs.scrapy.org/en/latest/topics/settings.html#stats-class
+.. _`spider settings`: https://support.scrapinghub.com/support/solutions/articles/22000200670-customizing-scrapy-settings-in-scrapy-cloud
 .. _`Scrapy Cloud`: https://scrapinghub.com/scrapy-cloud
 .. _`DotScrapy Persistence Add-on`: https://support.scrapinghub.com/support/solutions/articles/22000200401-dotscrapy-persistence-addon

--- a/docs/source/stats-collection.rst
+++ b/docs/source/stats-collection.rst
@@ -45,6 +45,9 @@ returned in the previous spider executions.
       def test_expected_number_of_items_extracted(self):
           spider = self.data["spider"]
           total_previous_jobs = len(spider.stats_history)
+          if total_previous_jobs == 0:
+              return
+
           previous_item_extracted_mean = (
               sum(
                   previous_job["item_scraped_count"]

--- a/docs/source/stats-collection.rst
+++ b/docs/source/stats-collection.rst
@@ -35,6 +35,8 @@ returned in the previous spider executions.
 .. code-block:: python
 
     # myproject/monitors.py
+    from spidermon import Monitor, MonitorSuite, monitors
+
 
     @monitors.name("History Validation")
     class HistoryMonitor(Monitor):
@@ -61,6 +63,9 @@ returned in the previous spider executions.
                   minimum_threshold
               ),
           )
+
+    class SpiderCloseMonitorSuite(MonitorSuite):
+        monitors = [HistoryMonitor]
 
 .. note::
     If you are running your spider in `Scrapy Cloud`_ you need to enable the


### PR DESCRIPTION
This should improve docs of using stats history in Scrapy Cloud to avoid users having the problem of #186 .