### PR TITLE
feature: Add option to set AWS Region Name on SES E-Mail action

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -70,8 +70,8 @@ AWS Secret Key.
 
 Default: ``None``
 
-SPIDERMON_AWS_REGION
-------------------------
+SPIDERMON_AWS_REGION_NAME
+-------------------------
 
 AWS Region.
 

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -70,6 +70,13 @@ AWS Secret Key.
 
 Default: ``None``
 
+SPIDERMON_AWS_REGION
+------------------------
+
+AWS Region.
+
+Default: ``us-east-1``
+
 .. _SPIDERMON_EMAIL_SENDER:
 
 SPIDERMON_EMAIL_SENDER

--- a/spidermon/contrib/actions/email/ses.py
+++ b/spidermon/contrib/actions/email/ses.py
@@ -9,15 +9,20 @@ from . import SendEmail
 class SendSESEmail(SendEmail):
     aws_access_key = None
     aws_secret_key = None
-    aws_region = "us-east-1"
+    aws_region_name = "us-east-1"
 
     def __init__(
-        self, aws_access_key=None, aws_secret_key=None, aws_region=None, *args, **kwargs
+        self,
+        aws_access_key=None,
+        aws_secret_key=None,
+        aws_region_name=None,
+        *args,
+        **kwargs
     ):
         super(SendSESEmail, self).__init__(*args, **kwargs)
         self.aws_access_key = aws_access_key or self.aws_access_key
         self.aws_secret_key = aws_secret_key or self.aws_secret_key
-        self.aws_region = aws_region or self.aws_region
+        self.aws_region_name = aws_region_name or self.aws_region_name
         if not self.fake and not self.aws_access_key:
             raise NotConfigured("You must provide the AWS Access Key.")
         if not self.fake and not self.aws_secret_key:
@@ -30,14 +35,14 @@ class SendSESEmail(SendEmail):
             {
                 "aws_access_key": crawler.settings.get("SPIDERMON_AWS_ACCESS_KEY"),
                 "aws_secret_key": crawler.settings.get("SPIDERMON_AWS_SECRET_KEY"),
-                "aws_region": crawler.settings.get("SPIDERMON_AWS_REGION"),
+                "aws_region_name": crawler.settings.get("SPIDERMON_AWS_REGION_NAME"),
             }
         )
         return kwargs
 
     def send_message(self, message):
         session = ses.connect_to_region(
-            self.aws_region,
+            self.aws_region_name,
             aws_access_key_id=self.aws_access_key,
             aws_secret_access_key=self.aws_secret_key,
         )


### PR DESCRIPTION
The function `boto.connect_ses` does not allow the usage of a different region other than the default `us-east-1`.
With this commit it will be possible to set the AWS region by adding `SPIDERMON_AWS_REGION` to the settings.py.