### PR TITLE
Added constrain on lxml version based on Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ test_requirements = [
     "pytest-cov",
     "pytest-mock",
     "jinja2",
+    "lxml;python_version!='3.4'",
+    "lxml<=4.3.5;python_version=='3.4'",
     "scrapy",
     "slackclient>=1.3.0,<2.0.0",
     'Twisted<=19.2.0;python_version=="3.4"',


### PR DESCRIPTION
lxml 4.4.0 dropped support for Python 3.4 and it is required by Scrapy package that is used by our tests, so while (this Scrapy issue)[https://github.com/scrapy/scrapy/issues/3912] is not fixed, we need this workaround to be able to execute Spidermon tests on Python 3.4.
