### PR TITLE
Enforce Black formatting through pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ python:
   - 3.7
 install:
   - pip install tox-travis
-script: tox
-after_success:
+script: 
+  - tox
   - if [[ "$TRAVIS_PYTHON_VERSION" == 3.7 ]]; then
     tox -e pep8;
     fi


### PR DESCRIPTION
- This enforces Black formatting through the Travis CI pipelines. After this PR, the builds would fail if the files are not black formatted. Gives a nice touch of uniformity. 

Here's how the output looks like running in the Python 3.7 environment. My master branch is clogged with a big merge, hence had to make patch through the GitHub editor.

![Screenshot_2019-08-29_21-34-46](https://user-images.githubusercontent.com/22801822/63971709-c809d880-cac4-11e9-8802-2aa3471d170e.png)

Let me know what you folks think. 
 