### PR TITLE
feature: Log errors from Slack API calls

### DIFF
--- a/spidermon/contrib/actions/slack/__init__.py
+++ b/spidermon/contrib/actions/slack/__init__.py
@@ -94,6 +94,12 @@ class SlackMessageManager:
 
     def _api_call(self, method, **kwargs):
         response = self._client.api_call(method, **kwargs)
+
+        has_errors = not response.get("ok")
+        if has_errors:
+            error_msg = response.get("error", {}).get("msg", "Slack API error")
+            logger.error(error_msg)
+
         if isinstance(response, six.string_types):  # slackclient < v1.0
             response = json.loads(response)
         return response

--- a/tests/contrib/actions/slack/test_slack_message_manager.py
+++ b/tests/contrib/actions/slack/test_slack_message_manager.py
@@ -1,0 +1,41 @@
+import pytest
+from spidermon.contrib.actions.slack import SlackMessageManager
+
+
+@pytest.fixture
+def logger_error(mocker):
+    return mocker.patch("spidermon.contrib.actions.slack.logger.error")
+
+
+def test_api_call_with_no_error_should_not_log_messages(mocker, logger_error):
+    api_valid_message = {"ok": True, "text": "valid response"}
+    mocker.patch(
+        "spidermon.contrib.actions.slack.SlackClient.api_call",
+        return_value=api_valid_message,
+    )
+    manager = SlackMessageManager("SENDER_TOKEN", "SENDER_NAME")
+
+    manager._api_call("some_method")
+
+    assert logger_error.call_count == 0
+
+
+def test_api_call_with_error_should_log_error_msg(mocker, logger_error):
+    error_msg = "API call failure"
+    # API call response with error (see https://api.slack.com/rtm#errors)
+    api_error_message = {
+        "ok": False,
+        "reply_to": 1,
+        "error": {"code": 2, "msg": error_msg},
+    }
+    mocker.patch(
+        "spidermon.contrib.actions.slack.SlackClient.api_call",
+        return_value=api_error_message,
+    )
+
+    manager = SlackMessageManager("SENDER_TOKEN", "SENDER_NAME")
+
+    manager._api_call("some_method")
+
+    assert logger_error.call_count == 1
+    assert error_msg in logger_error.call_args_list[0][0]


### PR DESCRIPTION
This should help identifying problems like #207 .
Slack action needs a better error handling from API responses, but I believe this needs another PR.