### PR TITLE
feature: Dropped Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: python
 dist: xenial
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
   - 3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py27,py35,py36,py37
 skip_missing_interpreters = True
 
 [testenv]
-extras = 
+extras =
     tests
     validation
 commands = pytest -s -W ignore::schematics.deprecated.SchematicsDeprecationWarning --cov-report= --cov=spidermon {posargs:tests}
 
 [testenv:pep8]
 extras = pep8
-commands = 
+commands =
     black ./ --check --diff


### PR DESCRIPTION
:hatching_chick: 
Remove Python 3.4 from list of Python environments.
Partially solves #223 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com