### PR TITLE
docs: Including extra steps to iclude Telegram bot notifications in groups and channels

### DIFF
--- a/docs/source/configuring-telegram-for-spidermon.rst
+++ b/docs/source/configuring-telegram-for-spidermon.rst
@@ -23,7 +23,7 @@ Steps
 4. Add the recipients to your Scrapy project's settings, getting the `chat_id` or `group_id` is not straightforward, there is an info bot that can help with this. Just forward a message from the user or group that you want to receive Spidermon notifications to `[@GroupIDbot](https://t.me/GroupIDbot)` and it will reply with the id. To forward a message from a group to the bot, you need to add the bot to that group before.
 
 5. For notifications in groups: `Add your self-created bot <https://telegram.org/faq#q-how-do-i-add-more-members-what-39s-an-invite-link>`_ (from step 1.) to your group.
-For notifictations in channels: Add your self-created bot (from step 1.) as administrator to your channel (not possible in browser version).
+For notifications in channels: Add your self-created bot (from step 1.) as administrator to your channel (not possible in browser version).
 
 
 .. note:

--- a/docs/source/configuring-telegram-for-spidermon.rst
+++ b/docs/source/configuring-telegram-for-spidermon.rst
@@ -20,7 +20,11 @@ Steps
 
 3. Add your Telegram bot credentials to your Scrapy project's settings.
 
-4. Add the recipients to your Scrapy project's settings, getting the `chat_id` or `group_id` is not straightforward, there is a bot that can help with this. Just forward a message from the user or group that you want to receive Spidermon notifications to `[@userinfobot](https://t.me/userinfobot)` and it will reply with the id.
+4. Add the recipients to your Scrapy project's settings, getting the `chat_id` or `group_id` is not straightforward, there is an info bot that can help with this. Just forward a message from the user or group that you want to receive Spidermon notifications to `[@GroupIDbot](https://t.me/GroupIDbot)` and it will reply with the id. To forward a message from a group to the bot, you need to add the bot to that group before.
+
+5. For notifications in groups: `Add your self-created bot <https://telegram.org/faq#q-how-do-i-add-more-members-what-39s-an-invite-link>`_ (from step 1.) to your group.
+For notifictations in channels: Add your self-created bot (from step 1.) as administrator to your channel (not possible in browser version).
+
 
 .. note:
     You need to add the bot to the group or channel so it can send messages. If you want the bot to send notifications to a user, first the user needs to start a conversation with the bot and send the command `/start`.


### PR DESCRIPTION
It is not possible to add [@userinfobot] to groups -> alternative: [@GroupIDbot]
It was not clear, that you need to add the info bot to the group to get the group id.
It was not clear, that you need to add your own bot to your group or (as admin) to your channel, to receive notifications in groups or channels.