### PR TITLE
chore: Remove test decorator that skips tests if executed in old Python versions

### DIFF
--- a/tests/contrib/scrapy/test_pipelines.py
+++ b/tests/contrib/scrapy/test_pipelines.py
@@ -213,9 +213,6 @@ class PipelineJSONSchemaValidator(PipelineTest):
     ]
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 4), reason="mock requires python3.4 or higher"
-)
 def test_validator_from_url(mocker):
     mocked_get_contents = mocker.patch(
         "spidermon.contrib.validation.jsonschema.tools.get_contents",

--- a/tests/test_spidermon_signal_connect.py
+++ b/tests/test_spidermon_signal_connect.py
@@ -16,7 +16,6 @@ def spidermon_enabled_settings():
     }
 
 
-@pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4 or higher")
 def test_spider_opened_connect_signal(mocker, spidermon_enabled_settings):
     spider_opened_method = mocker.patch.object(Spidermon, "spider_opened")
 
@@ -27,7 +26,6 @@ def test_spider_opened_connect_signal(mocker, spidermon_enabled_settings):
     assert spider_opened_method.called, "spider_opened not called"
 
 
-@pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4 or higher")
 def test_spider_closed_connect_signal(mocker, spidermon_enabled_settings):
     spider_closed_method = mocker.patch.object(Spidermon, "spider_closed")
 
@@ -40,7 +38,6 @@ def test_spider_closed_connect_signal(mocker, spidermon_enabled_settings):
     assert spider_closed_method.called, "spider_closed not called"
 
 
-@pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4 or higher")
 def test_engine_stopped_connect_signal(mocker, spidermon_enabled_settings):
     engine_stopped = mocker.patch.object(Spidermon, "engine_stopped")
 


### PR DESCRIPTION
As Spidermon supports only Python versions greater than 3.5. It is not necessary to have this decorator over the tests as they will never be executed in older Python versions anymore.