### PR TITLE
feature: Add field coverage statistics

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -116,3 +116,12 @@ SPIDERMON_ENGINE_STOP_EXPRESSION_MONITORS
 Default: ``[]``
 
 List of dictionaries describing :ref:`expression monitors<topics-expression-monitors>` to run when the engine is stopped.
+
+
+.. SPIDERMON_ADD_FIELD_COVERAGE:
+
+SPIDERMON_ADD_FIELD_COVERAGE
+----------------------------
+Default: ``False``
+
+When enabled, Spidermon will add field coverage information in Spider stats.

--- a/spidermon/contrib/scrapy/extensions.py
+++ b/spidermon/contrib/scrapy/extensions.py
@@ -107,6 +107,11 @@ class Spidermon(object):
         crawler.signals.connect(ext.spider_opened, signal=signals.spider_opened)
         crawler.signals.connect(ext.spider_closed, signal=signals.spider_closed)
         crawler.signals.connect(ext.engine_stopped, signal=signals.engine_stopped)
+
+        has_field_coverage = "SPIDERMON_FIELD_COVERAGE" in crawler.settings.keys()
+        if has_field_coverage:
+            crawler.signals.connect(ext.item_scraped, signal=signals.item_scraped)
+
         return ext
 
     def spider_opened(self, spider):
@@ -125,6 +130,9 @@ class Spidermon(object):
     def engine_stopped(self):
         spider = self.crawler.spider
         self._run_suites(spider, self.engine_stopped_suites)
+
+    def item_scraped(self, item, response, spider):
+        ...
 
     def _run_periodic_suites(self, spider, suites):
         suites = [self.load_suite(s) for s in suites]

--- a/spidermon/contrib/scrapy/extensions.py
+++ b/spidermon/contrib/scrapy/extensions.py
@@ -108,7 +108,7 @@ class Spidermon(object):
         crawler.signals.connect(ext.spider_closed, signal=signals.spider_closed)
         crawler.signals.connect(ext.engine_stopped, signal=signals.engine_stopped)
 
-        has_field_coverage = "SPIDERMON_FIELD_COVERAGE" in crawler.settings.keys()
+        has_field_coverage = crawler.settings.getbool("SPIDERMON_ADD_FIELD_COVERAGE")
         if has_field_coverage:
             crawler.signals.connect(ext.item_scraped, signal=signals.item_scraped)
 

--- a/spidermon/contrib/scrapy/extensions.py
+++ b/spidermon/contrib/scrapy/extensions.py
@@ -132,7 +132,12 @@ class Spidermon(object):
         self._run_suites(spider, self.engine_stopped_suites)
 
     def item_scraped(self, item, response, spider):
-        ...
+        self.crawler.stats.inc_value("spidermon_item_scraped_count")
+
+        item_type = type(item).__name__
+        self.crawler.stats.inc_value(
+            "spidermon_item_scraped_count/{}".format(item_type)
+        )
 
     def _run_periodic_suites(self, spider, suites):
         suites = [self.load_suite(s) for s in suites]

--- a/spidermon/contrib/scrapy/extensions.py
+++ b/spidermon/contrib/scrapy/extensions.py
@@ -9,6 +9,7 @@ from spidermon import MonitorSuite
 from spidermon.contrib.scrapy.runners import SpiderMonitorRunner
 from spidermon.python import factory
 from spidermon.python.monitors import ExpressionsMonitor
+from spidermon.utils.field_coverage import calculate_field_coverage
 from spidermon.utils.hubstorage import hs
 
 
@@ -123,6 +124,8 @@ class Spidermon(object):
             task.start(time, now=False)
 
     def spider_closed(self, spider):
+        self._add_field_coverage_to_stats()
+
         self._run_suites(spider, self.spider_closed_suites)
         for task in self.periodic_tasks[spider]:
             task.stop()
@@ -144,6 +147,11 @@ class Spidermon(object):
             if isinstance(value, dict):
                 self._count_item(value, field_item_count_stat)
                 continue
+
+    def _add_field_coverage_to_stats(self):
+        stats = self.crawler.stats.get_stats()
+        coverage_stats = calculate_field_coverage(stats)
+        stats.update(coverage_stats)
 
     def item_scraped(self, item, response, spider):
         self.crawler.stats.inc_value("spidermon_item_scraped_count")

--- a/spidermon/utils/field_coverage.py
+++ b/spidermon/utils/field_coverage.py
@@ -1,0 +1,26 @@
+import re
+
+
+def calculate_field_coverage(stats):
+    coverage = {}
+    for key, value in stats.items():
+        if not key.startswith("spidermon_item_scraped_count"):
+            continue
+
+        item_type_m = re.search(
+            r"spidermon_item_scraped_count\/(?P<item_type>\w+)\/(?P<item_key>.*)", key
+        )
+        if item_type_m:
+            item_type = item_type_m.group(1)
+            item_key = item_type_m.group(2)
+
+            item_type_total = stats.get(
+                "spidermon_item_scraped_count/{}".format(item_type)
+            )
+            field_coverage = value / item_type_total
+
+            coverage[
+                "spidermon_field_coverage/{}/{}".format(item_type, item_key)
+            ] = field_coverage
+
+    return coverage

--- a/tests/test_add_field_coverage.py
+++ b/tests/test_add_field_coverage.py
@@ -1,5 +1,5 @@
 import pytest
-from scrapy import Field, Item, signals
+from scrapy import Item, signals
 from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 
@@ -146,6 +146,19 @@ def test_item_scraped_count_multiple_nested_field(spider):
     assert stats.get("spidermon_item_scraped_count/dict/field1/field1.2") == 1
     assert stats.get("spidermon_item_scraped_count/dict/field2") == 2
     assert stats.get("spidermon_item_scraped_count/dict/field3") == 1
+
+
+def test_item_scraped_count_with_slash_on_field_name(spider):
+    returned_items = [{"field1/with/slash": "value1", "field2": "value2"}]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+    assert stats.get("spidermon_item_scraped_count/dict/field1/with/slash") == 1
+    assert stats.get("spidermon_item_scraped_count/dict/field2") == 1
 
 
 def test_do_not_add_field_coverage_when_spider_closes_if_do_not_have_field_coverage_settings():

--- a/tests/test_add_field_coverage.py
+++ b/tests/test_add_field_coverage.py
@@ -1,5 +1,3 @@
-
-
 import pytest
 from scrapy import Field, Item, signals
 from scrapy.spiders import Spider
@@ -148,3 +146,49 @@ def test_item_scraped_count_multiple_nested_field(spider):
     assert stats.get("spidermon_item_scraped_count/dict/field1/field1.2") == 1
     assert stats.get("spidermon_item_scraped_count/dict/field2") == 2
     assert stats.get("spidermon_item_scraped_count/dict/field3") == 1
+
+
+def test_do_not_add_field_coverage_when_spider_closes_if_do_not_have_field_coverage_settings():
+    settings = {
+        "SPIDERMON_ENABLED": True,
+        "EXTENSIONS": {"spidermon.contrib.scrapy.extensions.Spidermon": 100},
+        "SPIDERMON_ADD_FIELD_COVERAGE": False,
+    }
+    crawler = get_crawler(settings_dict=settings)
+    spider = Spider.from_crawler(crawler, "example.com")
+
+    item = {"field1": "value1"}
+    spider.crawler.signals.send_catch_log_deferred(
+        signal=signals.item_scraped, item=item, response="", spider=spider,
+    )  # Return item to have some stats to calculate coverage
+
+    crawler.signals.send_catch_log(
+        signal=signals.spider_closed, spider=spider, reason=None
+    )
+
+    stats = spider.crawler.stats.get_stats()
+
+    assert stats.get("spidermon_field_coverage/dict/field1") is None
+
+
+def test_add_field_coverage_when_spider_closes_if_have_field_coverage_settings():
+    settings = {
+        "SPIDERMON_ENABLED": True,
+        "EXTENSIONS": {"spidermon.contrib.scrapy.extensions.Spidermon": 100},
+        "SPIDERMON_ADD_FIELD_COVERAGE": True,
+    }
+    crawler = get_crawler(settings_dict=settings)
+    spider = Spider.from_crawler(crawler, "example.com")
+
+    item = {"field1": "value1"}
+    spider.crawler.signals.send_catch_log_deferred(
+        signal=signals.item_scraped, item=item, response="", spider=spider,
+    )  # Return item to have some stats to calculate coverage
+
+    crawler.signals.send_catch_log(
+        signal=signals.spider_closed, spider=spider, reason=None
+    )
+
+    stats = spider.crawler.stats.get_stats()
+
+    assert stats.get("spidermon_field_coverage/dict/field1") == 1.0

--- a/tests/test_item_scraped_signal.py
+++ b/tests/test_item_scraped_signal.py
@@ -1,0 +1,43 @@
+from scrapy import Item, signals
+from scrapy.spiders import Spider
+from scrapy.utils.test import get_crawler
+
+
+class TestItem(Item):
+    ...
+
+
+def test_add_stats_item_scraped_count_by_item_type():
+    settings = {
+        "SPIDERMON_ENABLED": True,
+        "EXTENSIONS": {"spidermon.contrib.scrapy.extensions.Spidermon": 100},
+        "SPIDERMON_FIELD_COVERAGE": {},
+    }
+    crawler = get_crawler(settings_dict=settings)
+
+    spider = Spider.from_crawler(crawler, "example.com")
+
+    for _ in range(15):
+        crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped,
+            item={"_type": "regular_dict"},
+            response="",
+            spider=spider,
+        )
+
+    for _ in range(20):
+        crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=Item(), response="", spider=spider,
+        )
+
+    for _ in range(25):
+        crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=TestItem(), response="", spider=spider,
+        )
+
+    stats = crawler.stats.get_stats()
+
+    assert stats.get("spidermon_item_scraped_count") == 60
+    assert stats.get("spidermon_item_scraped_count/dict") == 15
+    assert stats.get("spidermon_item_scraped_count/Item") == 20
+    assert stats.get("spidermon_item_scraped_count/TestItem") == 25

--- a/tests/test_item_scraped_signal.py
+++ b/tests/test_item_scraped_signal.py
@@ -49,3 +49,102 @@ def test_add_stats_item_scraped_count_by_item_type(spider):
     assert stats.get("spidermon_item_scraped_count/dict") == 15
     assert stats.get("spidermon_item_scraped_count/Item") == 20
     assert stats.get("spidermon_item_scraped_count/TestItem") == 25
+
+
+def test_item_scraped_count_single_field(spider):
+    returned_items = [{"field1": "value1"}]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 1
+
+
+def test_item_scraped_count_multiple_field(spider):
+    returned_items = [{"field1": "value1", "field2": "value2"}]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 1
+    assert stats.get("spidermon_item_scraped_count/dict/field2") == 1
+
+
+def test_item_scraped_count_multiple_items(spider):
+    returned_items = [
+        {"field1": "value1", "field2": "value2"},
+        {"field1": "value1", "field2": "value2"},
+    ]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field2") == 2
+
+
+def test_item_scraped_count_multiple_items_field_missing(spider):
+    returned_items = [
+        {"field1": "value1", "field2": "value2"},
+        {"field1": "value1",},
+    ]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field2") == 1
+
+
+def test_item_scraped_count_single_nested_field(spider):
+    returned_items = [{"field1": {"field1.1": "value1.1"}}]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+    assert stats.get("spidermon_item_scraped_count/dict") == 1
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 1
+    assert stats.get("spidermon_item_scraped_count/dict/field1/field1.1") == 1
+
+
+def test_item_scraped_count_multiple_nested_field(spider):
+    returned_items = [
+        {
+            "field1": {"field1.1": "value1.1"},
+            "field2": "value2",
+            "field3": {"field3.1": "value3.1"},
+        },
+        {
+            "field1": {"field1.1": "value1.1", "field1.2": "value1.2",},
+            "field2": "value2",
+        },
+    ]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+
+    assert stats.get("spidermon_item_scraped_count/dict") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field1/field1.1") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field1/field1.2") == 1
+    assert stats.get("spidermon_item_scraped_count/dict/field2") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field3") == 1

--- a/tests/test_item_scraped_signal.py
+++ b/tests/test_item_scraped_signal.py
@@ -1,0 +1,194 @@
+import pytest
+from scrapy import Item, signals
+from scrapy.spiders import Spider
+from scrapy.utils.test import get_crawler
+
+
+class TestItem(Item):
+    ...
+
+
+@pytest.fixture
+def spider():
+    settings = {
+        "SPIDERMON_ENABLED": True,
+        "EXTENSIONS": {"spidermon.contrib.scrapy.extensions.Spidermon": 100},
+        "SPIDERMON_ADD_FIELD_COVERAGE": True,
+    }
+    crawler = get_crawler(settings_dict=settings)
+
+    spider = Spider.from_crawler(crawler, "example.com")
+
+    return spider
+
+
+def test_add_stats_item_scraped_count_by_item_type(spider):
+    for _ in range(15):
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped,
+            item={"_type": "regular_dict"},
+            response="",
+            spider=spider,
+        )
+
+    for _ in range(20):
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=Item(), response="", spider=spider,
+        )
+
+    for _ in range(25):
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=TestItem(), response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+
+    assert stats.get("spidermon_item_scraped_count") == 60
+    assert stats.get("spidermon_item_scraped_count/dict") == 15
+    assert stats.get("spidermon_item_scraped_count/Item") == 20
+    assert stats.get("spidermon_item_scraped_count/TestItem") == 25
+
+
+def test_item_scraped_count_single_field(spider):
+    returned_items = [{"field1": "value1"}]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 1
+
+
+def test_item_scraped_count_multiple_field(spider):
+    returned_items = [{"field1": "value1", "field2": "value2"}]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 1
+    assert stats.get("spidermon_item_scraped_count/dict/field2") == 1
+
+
+def test_item_scraped_count_multiple_items(spider):
+    returned_items = [
+        {"field1": "value1", "field2": "value2"},
+        {"field1": "value1", "field2": "value2"},
+    ]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field2") == 2
+
+
+def test_item_scraped_count_multiple_items_field_missing(spider):
+    returned_items = [
+        {"field1": "value1", "field2": "value2"},
+        {"field1": "value1",},
+    ]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field2") == 1
+
+
+def test_item_scraped_count_single_nested_field(spider):
+    returned_items = [{"field1": {"field1.1": "value1.1"}}]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+    assert stats.get("spidermon_item_scraped_count/dict") == 1
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 1
+    assert stats.get("spidermon_item_scraped_count/dict/field1/field1.1") == 1
+
+
+def test_item_scraped_count_multiple_nested_field(spider):
+    returned_items = [
+        {
+            "field1": {"field1.1": "value1.1"},
+            "field2": "value2",
+            "field3": {"field3.1": "value3.1"},
+        },
+        {
+            "field1": {"field1.1": "value1.1", "field1.2": "value1.2",},
+            "field2": "value2",
+        },
+    ]
+
+    for item in returned_items:
+        spider.crawler.signals.send_catch_log_deferred(
+            signal=signals.item_scraped, item=item, response="", spider=spider,
+        )
+
+    stats = spider.crawler.stats.get_stats()
+
+    assert stats.get("spidermon_item_scraped_count/dict") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field1") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field1/field1.1") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field1/field1.2") == 1
+    assert stats.get("spidermon_item_scraped_count/dict/field2") == 2
+    assert stats.get("spidermon_item_scraped_count/dict/field3") == 1
+
+
+def test_do_not_add_field_coverage_when_spider_closes_if_do_not_have_field_coverage_settings():
+    settings = {
+        "SPIDERMON_ENABLED": True,
+        "EXTENSIONS": {"spidermon.contrib.scrapy.extensions.Spidermon": 100},
+        "SPIDERMON_ADD_FIELD_COVERAGE": False,
+    }
+    crawler = get_crawler(settings_dict=settings)
+    spider = Spider.from_crawler(crawler, "example.com")
+
+    item = {"field1": "value1"}
+    spider.crawler.signals.send_catch_log_deferred(
+        signal=signals.item_scraped, item=item, response="", spider=spider,
+    )  # Return item to have some stats to calculate coverage
+
+    crawler.signals.send_catch_log(
+        signal=signals.spider_closed, spider=spider, reason=None
+    )
+
+    stats = spider.crawler.stats.get_stats()
+
+    assert stats.get("spidermon_field_coverage/dict/field1") is None
+
+
+def test_add_field_coverage_when_spider_closes_if_have_field_coverage_settings():
+    settings = {
+        "SPIDERMON_ENABLED": True,
+        "EXTENSIONS": {"spidermon.contrib.scrapy.extensions.Spidermon": 100},
+        "SPIDERMON_ADD_FIELD_COVERAGE": True,
+    }
+    crawler = get_crawler(settings_dict=settings)
+    spider = Spider.from_crawler(crawler, "example.com")
+
+    item = {"field1": "value1"}
+    spider.crawler.signals.send_catch_log_deferred(
+        signal=signals.item_scraped, item=item, response="", spider=spider,
+    )  # Return item to have some stats to calculate coverage
+
+    crawler.signals.send_catch_log(
+        signal=signals.spider_closed, spider=spider, reason=None
+    )
+
+    stats = spider.crawler.stats.get_stats()
+
+    assert stats.get("spidermon_field_coverage/dict/field1") == 1.0

--- a/tests/test_item_scraped_signal.py
+++ b/tests/test_item_scraped_signal.py
@@ -15,7 +15,7 @@ def spider():
     settings = {
         "SPIDERMON_ENABLED": True,
         "EXTENSIONS": {"spidermon.contrib.scrapy.extensions.Spidermon": 100},
-        "SPIDERMON_FIELD_COVERAGE": {},
+        "SPIDERMON_ADD_FIELD_COVERAGE": True,
     }
     crawler = get_crawler(settings_dict=settings)
 

--- a/tests/test_spidermon_signal_connect.py
+++ b/tests/test_spidermon_signal_connect.py
@@ -53,18 +53,33 @@ def test_engine_stopped_connect_signal(mocker, spidermon_enabled_settings):
     assert engine_stopped.called, "engine_stopped not called"
 
 
-def test_item_scraped_connect_signal_if_has_field_coverage_settings(
+def test_item_scraped_connect_signal_if_field_coverage_settings_enabled(
     mocker, spidermon_enabled_settings
 ):
     item_scraped_method = mocker.patch.object(Spidermon, "item_scraped")
 
-    spidermon_enabled_settings["SPIDERMON_FIELD_COVERAGE"] = {}
+    spidermon_enabled_settings["SPIDERMON_ADD_FIELD_COVERAGE"] = True
     crawler = get_crawler(settings_dict=spidermon_enabled_settings)
 
     spider = Spider.from_crawler(crawler, "example.com")
     crawler.signals.send_catch_log(signal=signals.item_scraped, spider=spider)
 
     assert item_scraped_method.called, "item_scraped_method not called"
+
+
+def test_item_scraped_do_not_connect_signal_if_field_coverage_settings_disabled(
+    mocker, spidermon_enabled_settings
+):
+    item_scraped_method = mocker.patch.object(Spidermon, "item_scraped")
+
+    spidermon_enabled_settings["SPIDERMON_ADD_FIELD_COVERAGE"] = False
+
+    crawler = get_crawler(settings_dict=spidermon_enabled_settings)
+
+    spider = Spider.from_crawler(crawler, "example.com")
+    crawler.signals.send_catch_log(signal=signals.item_scraped, spider=spider)
+
+    assert not item_scraped_method.called, "item_scraped_method called"
 
 
 def test_item_scraped_do_not_connect_signal_if_do_not_have_field_coverage_settings(

--- a/tests/test_spidermon_signal_connect.py
+++ b/tests/test_spidermon_signal_connect.py
@@ -51,3 +51,30 @@ def test_engine_stopped_connect_signal(mocker, spidermon_enabled_settings):
     )
 
     assert engine_stopped.called, "engine_stopped not called"
+
+
+def test_item_scraped_connect_signal_if_has_field_coverage_settings(
+    mocker, spidermon_enabled_settings
+):
+    item_scraped_method = mocker.patch.object(Spidermon, "item_scraped")
+
+    spidermon_enabled_settings["SPIDERMON_FIELD_COVERAGE"] = {}
+    crawler = get_crawler(settings_dict=spidermon_enabled_settings)
+
+    spider = Spider.from_crawler(crawler, "example.com")
+    crawler.signals.send_catch_log(signal=signals.item_scraped, spider=spider)
+
+    assert item_scraped_method.called, "item_scraped_method not called"
+
+
+def test_item_scraped_do_not_connect_signal_if_do_not_have_field_coverage_settings(
+    mocker, spidermon_enabled_settings
+):
+    item_scraped_method = mocker.patch.object(Spidermon, "item_scraped")
+
+    crawler = get_crawler(settings_dict=spidermon_enabled_settings)
+
+    spider = Spider.from_crawler(crawler, "example.com")
+    crawler.signals.send_catch_log(signal=signals.item_scraped, spider=spider)
+
+    assert not item_scraped_method.called, "item_scraped_method called"

--- a/tests/utils/test_field_coverage.py
+++ b/tests/utils/test_field_coverage.py
@@ -1,0 +1,26 @@
+from spidermon.utils.field_coverage import calculate_field_coverage
+
+
+def test_calculate_field_coverage_from_stats():
+    spider_stats = {
+        "finish_reason": "finished",
+        "spidermon_item_scraped_count": 100,
+        "spidermon_item_scraped_count/dict": 100,
+        "spidermon_item_scraped_count/dict/author": 100,
+        "spidermon_item_scraped_count/dict/author/author_url": 64,
+        "spidermon_item_scraped_count/dict/author/name": 100,
+        "spidermon_item_scraped_count/dict/quote": 50,
+        "spidermon_item_scraped_count/dict/tags": 100,
+    }
+
+    expected_coverage = {
+        "spidermon_field_coverage/dict/author": 1.0,
+        "spidermon_field_coverage/dict/author/author_url": 0.64,
+        "spidermon_field_coverage/dict/author/name": 1.0,
+        "spidermon_field_coverage/dict/quote": 0.5,
+        "spidermon_field_coverage/dict/tags": 1.0,
+    }
+
+    coverage = calculate_field_coverage(spider_stats)
+
+    assert coverage == expected_coverage


### PR DESCRIPTION
After this PR is merged, it will be easier to implement #253 as a new built-in monitor for field coverage.

When `SPIDERMON_ADD_FIELD_COVERAGE` is enabled, it will include a new set of stats containing information about field coverage for different item types, making it possible to use these stats in custom monitors.