### PR TITLE
Drop official support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ git:
 language: python
 dist: xenial
 python:
-  - 3.5
   - 3.6
   - 3.7
+  - 3.8
 install:
   - pip install tox-travis codecov
 script:
   - tox
-  - if [[ "$TRAVIS_PYTHON_VERSION" == 3.7 ]]; then
+  - if [[ "$TRAVIS_PYTHON_VERSION" == 3.8 ]]; then
     tox -e docs;
     tox -e pep8;
     fi
@@ -24,7 +24,7 @@ deploy:
   on:
     tags: true
     repo: scrapinghub/spidermon
-    condition: "$TRAVIS_PYTHON_VERSION == '3.7'"
+    condition: "$TRAVIS_PYTHON_VERSION == '3.8'"
   user: scrapinghub
   password:
     secure: MRPUDxyYlLvIYzflLiLlEYEN1qvs5IMI1llCJea/KPV45XlduCzy3v0Dc9Em+MlW+gkIe1F5SgcNPMvRk8CtAlt4/mUZmelRxxkqKzY51xMbEVDUAPbg7ZLRcAzgOe16dqtXl8DpQJEhn87z/YXEdDU/TRz29/reNf8M/m+40m31+37WBvH7bNVf1A0jJb8Y/EIVXl/xGehIWv4U/q5HzW8NTEIUAtCOPSyJf8kIWkHO6qgJxaDJGS9CBb+m3zpWIVaBapqPtQhPDsW2YNZvlFoohU1qcmOmuu6Zah7uD34kXGSDGl7KHO7BlCjxAQ7m6Pwfc0PFy6TUFhGSoPZyh1DUKXv2MM361FdK1qoxa0PrSs0vNZU4xTvWXL98/9u0Q20lgzPlm8jUxmIgSqsStK+oPT5QNyxCTNZC5kytr36ZdacXUAqHEfmRnGcQxSH1Z/Q8/FkT1FZyn5BG4hBmQCQto4nB7ly3E+5pJQHxhJUv7GOP70rUTdc1lo1+cfDKGaqonIjlGW7VUpPaw6ZMSkYw2Xf+E7wtOoRuKuHP7bD1KfRr8WkyLavESYbHgFp2+hl6es/NM1y+vCvHcYBA1u9gPMuF3PD+AEA5CSqYrJLAqadOzoyJ6WmRGi1utgi+Cfeq/5rr8xFehJaIx8+2PCqkKRcNuN0WINM/qZJfg64=

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Spidermon is an extension for Scrapy spiders. The package provides useful tools 
 Requirements
 ============
 
-* Python 3.5, Python 3.6, Python 3.7 or Python 3.8
+* Python 3.6, Python 3.7 or Python 3.8
 
 Install
 =======

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ pytest
 pytest-cov
 tox
 sentry-sdk
-black; python_version >= '3.6'
+black
 pytest-mock

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -59,4 +59,5 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: System :: Monitoring",
     ],
+    python_requires=">=3.6",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py36,py37,py38
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This PR solves #266 

I didn't find any code that is only used for Python 3.5, so just removing it from setup, documentation and CI settings should be enough.