### PR TITLE
Test on Python 3.9-dev and 3.10-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 git:
   depth: false
   quiet: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9-dev
+  - 3.10-dev
 install:
   - pip install tox-travis codecov
 script:


### PR DESCRIPTION
Python 3.9.0 is due out next month, it's a good idea to test the release candidate already, to make sure both this library and Python itself are working.

* https://www.python.org/dev/peps/pep-0596/#release-schedule

Optionally 3.10-dev can be tested too, although it's not yet in alpha.

* https://www.python.org/dev/peps/pep-0619/#release-schedule

Also remove `sudo: false`, it no longer does anything: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration