### PR TITLE
chore: Fix deprecation warnings

### DIFF
--- a/spidermon/contrib/scrapy/pipelines.py
+++ b/spidermon/contrib/scrapy/pipelines.py
@@ -8,7 +8,7 @@ from scrapy.exceptions import DropItem, NotConfigured
 from scrapy.utils.misc import load_object
 from scrapy.exporters import JsonLinesItemExporter
 from scrapy import Field, Item
-from scrapy.utils.python import to_native_str
+from scrapy.utils.python import to_unicode
 
 from spidermon.contrib.validation import SchematicsValidator, JSONSchemaValidator
 from spidermon.contrib.validation.jsonschema.tools import get_schema_from
@@ -141,7 +141,7 @@ class ItemValidationPipeline(object):
         serialized_json = BytesIO()
         exporter = JsonLinesItemExporter(serialized_json)
         exporter.export_item(item)
-        data = json.loads(to_native_str(serialized_json.getvalue(), exporter.encoding))
+        data = json.loads(to_unicode(serialized_json.getvalue(), exporter.encoding))
         serialized_json.close()
         return data
 

--- a/spidermon/contrib/stats/counters.py
+++ b/spidermon/contrib/stats/counters.py
@@ -37,7 +37,7 @@ class PercentCounter(PercentCounterBase):
         self._count += value
 
 
-class DictPercentCounter(PercentCounterBase, collections.MutableMapping):
+class DictPercentCounter(PercentCounterBase, collections.abc.MutableMapping):
     __items_class__ = PercentCounter
 
     def __init__(self, total):


### PR DESCRIPTION
```
  /home/travis/build/scrapinghub/spidermon/spidermon/contrib/stats/counters.py:40: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    class DictPercentCounter(PercentCounterBase, collections.MutableMapping):
...
  /home/travis/build/scrapinghub/spidermon/spidermon/contrib/scrapy/pipelines.py:144: ScrapyDeprecationWarning: Call to deprecated function to_native_str. Use to_unicode instead.
    data = json.loads(to_native_str(serialized_json.getvalue(), exporter.encoding))
```
https://travis-ci.org/github/scrapinghub/spidermon/jobs/725926867#L289
https://travis-ci.org/github/scrapinghub/spidermon/jobs/725926867#L305