### PR TITLE
chore: Fix warnings when running tests

### DIFF
--- a/tests/test_add_field_coverage.py
+++ b/tests/test_add_field_coverage.py
@@ -5,7 +5,8 @@ from scrapy.utils.test import get_crawler
 
 
 class TestItem(Item):
-    ...
+
+    __test__ = False
 
 
 @pytest.fixture

--- a/tests/test_item_scraped_signal.py
+++ b/tests/test_item_scraped_signal.py
@@ -5,7 +5,8 @@ from scrapy.utils.test import get_crawler
 
 
 class TestItem(Item):
-    ...
+
+    __test__ = False
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR will remove `PytestCollectionWarning` raised every time we run
the tests. This was happening because we have some test classes (thar
are not tests) trying to be collected by pytest.