### PR TITLE
docs: Add warning regarding execution order of item validation pipeline

### DIFF
--- a/docs/source/item-validation.rst
+++ b/docs/source/item-validation.rst
@@ -15,6 +15,12 @@ the first step is to enable the built-in item pipeline in your project settings:
         'spidermon.contrib.scrapy.pipelines.ItemValidationPipeline': 800,
     }
 
+.. warning::
+
+  Preferably, enable it as the last pipeline executed, ensuring that no
+  subsequent pipeline changes the content of the item, ignoring the
+  validation already performed.
+
 After that, you need to choose which validation library will be used. Spidermon
 accepts schemas defined using schematics_ or `JSON Schema`_.
 


### PR DESCRIPTION
This happened in a real project. I enabled this pipeline, but added subsequent pipelines that changed the content of a valid item to an invalid content. This left me with an invalid item, but no validation error was raised. Adding this warning should prevent this kind of error (for the ones that read the docs :smile: ).