### PR TITLE
Update translation regex to identify new schematics message

### DIFF
--- a/spidermon/contrib/validation/schematics/translator.py
+++ b/spidermon/contrib/validation/schematics/translator.py
@@ -8,7 +8,7 @@ class SchematicsMessageTranslator(MessageTranslator):
         r"^Rogue field$": messages.UNEXPECTED_FIELD,
         # BaseType
         r"^This field is required.$": messages.MISSING_REQUIRED_FIELD,
-        r"^Value must be one of .*\.$": messages.VALUE_NOT_IN_CHOICES,
+        r"^Value \(.*?\) must be one of \[.*?\]\.$": messages.VALUE_NOT_IN_CHOICES,
         # StringType
         r"^Couldn't interpret '.*' as string\.$": messages.INVALID_STRING,
         r"^String value is too long\.$": messages.FIELD_TOO_LONG,


### PR DESCRIPTION
Schematics 2.1.1 changed the [error message](https://github.com/schematics/schematics/commit/787c7f27acee37a85c6a9eda6eb53a19cd38c89a#diff-e6a5aa2776fcdc843a6af32fdefdb50ef37ece6ab470f1c4ab1580aecd61a418L168) when a value doesn't match one of the available choices of a field.

This commit updates the regex used to identify this message, so it continues being translated to the common `messages.VALUE_NOT_IN_CHOICES` that is shared amongst all validator libraries.