### PR TITLE
Fix invalid JSON schema in documentation

### DIFF
--- a/docs/source/item-validation.rst
+++ b/docs/source/item-validation.rst
@@ -81,7 +81,10 @@ an example of a schema for the quotes item from the :doc:`tutorial </getting-sta
         "pattern": ""
       },
       "tags": {
-        "type"
+        "type": "array",
+        "items": {
+          "type":"string"
+        }
       }
     },
     "required": [


### PR DESCRIPTION
JSON Schema in the docs was invalid and it wouldn't work if someone try to use it.