### PR TITLE
Create Base Stat Monitor class to help creating custom monitors

### DIFF
--- a/docs/source/monitors.rst
+++ b/docs/source/monitors.rst
@@ -130,6 +130,21 @@ Here is an example of how to configure a new monitor suite in your project:
 
       ``result`` stats of the spider execution
 
+Base Stat Monitor
+-----------------
+
+Most of the monitors we create validate a numerical value from job stats against a configurable
+threshold. This is a common pattern that leads us to create almost repeated code for any new monitor
+we add to our projects.
+
+To reduce the amount of boilerplate code, we have this base class that your custom monitor can
+inherit from and with a few attributes you end with a full functional monitor that just needs
+to be added to your Monitor Suite to be used.
+
+.. automodule:: spidermon.contrib.scrapy.monitors
+    :members: BaseStatMonitor
+    :noindex:
+
 The Basic Monitors
 ------------------
 

--- a/spidermon/contrib/scrapy/monitors.py
+++ b/spidermon/contrib/scrapy/monitors.py
@@ -28,6 +28,54 @@ class BaseScrapyMonitor(Monitor, SpiderMonitorMixin):
 
 
 class BaseStatMonitor(BaseScrapyMonitor):
+    """Base Monitor class for stat-related monitors.
+
+    Create a monitor class inheriting from this class to have a custom
+    monitor that validates numerical stats from your job execution
+    against a configurable threshold.
+
+    As an example, we will create a new monitor that will check if the
+    value obtained in a job stat 'numerical_job_statistic' is greater than
+    or equal to the value configured in ``CUSTOM_STAT_THRESHOLD`` project
+    setting:
+
+    .. code-block:: python
+
+        class MyCustomStatMonitor(BaseStatMonitor):
+            stat_name = "numerical_job_statistic"
+            threshold_setting = "CUSTOM_STAT_THRESHOLD"
+            assert_type = ">="
+
+    For the ``assert_type`` property you can select one of the following:
+
+    ==  =====================
+    >   Greater than
+    >=  Greater than or equal
+    <   Less than
+    <=  Less than or equal
+    ==  Equal
+    !=  Not equal
+    ==  =====================
+
+    Sometimes, we don't want a fixed threshold, but a dynamic based on more than
+    one stat or getting data external from the job execution (e.g., you want the
+    threshold to be related to another stat, or you want to get the value
+    of a stat from a previous job).
+
+    As an example, the following monitor will use as threshold the a variable number
+    of errors allowed based on the number of items scraped. So this monitor will pass
+    only if the number of errors is less than 1% of the number of items scraped:
+
+    .. code-block:: python
+
+        class MyCustomStatMonitor(BaseStatMonitor):
+            stat_name = "log_count/ERROR"
+            assert_type = "<"
+
+            def get_threshold(self):
+                item_scraped_count = self.stats.get("item_scraped_count")
+                return item_scraped_count * 0.01"""
+
     def run(self, result):
         has_threshold_config = any(
             [hasattr(self, "threshold_setting"), hasattr(self, "get_threshold")]

--- a/spidermon/contrib/scrapy/monitors.py
+++ b/spidermon/contrib/scrapy/monitors.py
@@ -1,4 +1,3 @@
-from enum import Enum, auto
 from spidermon import Monitor, MonitorSuite, monitors
 from spidermon.exceptions import NotConfigured
 from spidermon.utils.settings import getdictorlist
@@ -16,15 +15,6 @@ SPIDERMON_MAX_RETRIES = "SPIDERMON_MAX_RETRIES"
 SPIDERMON_MAX_DOWNLOADER_EXCEPTIONS = "SPIDERMON_MAX_DOWNLOADER_EXCEPTIONS"
 SPIDERMON_MIN_SUCCESSFUL_REQUESTS = "SPIDERMON_MIN_SUCCESSFUL_REQUESTS"
 SPIDERMON_MAX_REQUESTS_ALLOWED = "SPIDERMON_MAX_REQUESTS_ALLOWED"
-
-
-class AssertionType(Enum):
-    EQ = "EQUAL"
-    NEQ = "NOT EQUAL"
-    GT = "GREATER THAN"
-    GTE = "GREATER THAN OR EQUAL"
-    LT = "LESS THAN"
-    LTE = "LESS THAN OR EQUAL"
 
 
 class BaseScrapyMonitor(Monitor, SpiderMonitorMixin):
@@ -67,12 +57,12 @@ class BaseStatMonitor(BaseScrapyMonitor):
 
     def test_stat_monitor(self):
         assertions = {
-            AssertionType.GT: self.assertGreater,
-            AssertionType.GTE: self.assertGreaterEqual,
-            AssertionType.LT: self.assertLess,
-            AssertionType.LTE: self.assertLessEqual,
-            AssertionType.EQ: self.assertEqual,
-            AssertionType.NEQ: self.assertNotEqual,
+            ">": self.assertGreater,
+            ">=": self.assertGreaterEqual,
+            "<": self.assertLess,
+            "<=": self.assertLessEqual,
+            "==": self.assertEqual,
+            "!=": self.assertNotEqual,
         }
         threshold = self._get_threshold_value()
         value = self.stats.get(self.stat_name)
@@ -81,8 +71,8 @@ class BaseStatMonitor(BaseScrapyMonitor):
         assertion_method(
             value,
             threshold,
-            msg=f"'{self.stat_name}' - expected: {self.assert_type.value} "
-            f"to {threshold} - obtained: {value}",
+            msg=f"Expecting '{self.stat_name}' to be '{self.assert_type}' "
+            f"to '{threshold}'. Current value: '{value}'",
         )
 
 

--- a/spidermon/results/monitor.py
+++ b/spidermon/results/monitor.py
@@ -107,7 +107,7 @@ class MonitorResult(unittest.TestResult):
     @monitors_step_required
     def addSkip(self, test, reason):
         super().addSkip(test, reason)
-        self.step[test].status = settings.MONITOR.STATUS.FAILURE
+        self.step[test].status = settings.MONITOR.STATUS.SKIPPED
         self.step[test].reason = reason
 
     @monitors_step_required

--- a/tests/contrib/scrapy/monitors/test_base_stat_monitor.py
+++ b/tests/contrib/scrapy/monitors/test_base_stat_monitor.py
@@ -115,3 +115,54 @@ def test_failure_message_describe_values_expected(make_data):
         == f"Expecting '{TestBaseStatMonitor.stat_name}' to be '{TestBaseStatMonitor.assert_type}' "
         f"to '{expected_threshold}'. Current value: '{obtained_value}'",
     )
+
+
+def test_fail_if_stat_can_not_be_found(make_data):
+    class TestBaseStatMonitor(BaseStatMonitor):
+        stat_name = "test_statistic"
+        threshold_setting = "THRESHOLD_SETTING"
+        assert_type = ">="
+
+    data = make_data({"THRESHOLD_SETTING": 100})
+    runner = data.pop("runner")
+    data["stats"] = {"other_stats": 1}
+    monitor_suite = MonitorSuite(monitors=[TestBaseStatMonitor])
+
+    runner.run(monitor_suite, **data)
+    assert runner.result.monitor_results[0].status == settings.MONITOR.STATUS.FAILURE
+
+
+def test_success_if_stat_can_not_be_found_but_monitor_configured_to_not_ignore_it(
+    make_data,
+):
+    class TestBaseStatMonitor(BaseStatMonitor):
+        stat_name = "test_statistic"
+        threshold_setting = "THRESHOLD_SETTING"
+        assert_type = ">="
+        fail_if_stat_missing = True
+
+    data = make_data({"THRESHOLD_SETTING": 100})
+    runner = data.pop("runner")
+    data["stats"] = {"other_stats": 1}
+    monitor_suite = MonitorSuite(monitors=[TestBaseStatMonitor])
+
+    runner.run(monitor_suite, **data)
+    assert runner.result.monitor_results[0].status == settings.MONITOR.STATUS.FAILURE
+
+
+def test_skipped_if_stat_can_not_be_found_but_monitor_configured_to_be_ignore(
+    make_data,
+):
+    class TestBaseStatMonitor(BaseStatMonitor):
+        stat_name = "test_statistic"
+        threshold_setting = "THRESHOLD_SETTING"
+        assert_type = ">="
+        fail_if_stat_missing = False
+
+    data = make_data({"THRESHOLD_SETTING": 100})
+    runner = data.pop("runner")
+    data["stats"] = {"other_stats": 1}
+    monitor_suite = MonitorSuite(monitors=[TestBaseStatMonitor])
+
+    runner.run(monitor_suite, **data)
+    assert runner.result.monitor_results[0].status == settings.MONITOR.STATUS.SKIPPED

--- a/tests/contrib/scrapy/monitors/test_base_stat_monitor.py
+++ b/tests/contrib/scrapy/monitors/test_base_stat_monitor.py
@@ -1,0 +1,118 @@
+import pytest
+from spidermon.contrib.scrapy.monitors import (
+    BaseStatMonitor,
+    AssertionType,
+)
+from spidermon import MonitorSuite
+from spidermon.exceptions import NotConfigured
+from spidermon import settings
+
+
+@pytest.mark.parametrize(
+    "assertion_type,stat_value,threshold,expected_status",
+    [
+        (AssertionType.EQ, 90, 100, settings.MONITOR.STATUS.FAILURE),
+        (AssertionType.EQ, 100, 100, settings.MONITOR.STATUS.SUCCESS),
+        (AssertionType.EQ, 110, 100, settings.MONITOR.STATUS.FAILURE),
+        (AssertionType.NEQ, 90, 100, settings.MONITOR.STATUS.SUCCESS),
+        (AssertionType.NEQ, 100, 100, settings.MONITOR.STATUS.FAILURE),
+        (AssertionType.NEQ, 110, 100, settings.MONITOR.STATUS.SUCCESS),
+        (AssertionType.GT, 99, 100, settings.MONITOR.STATUS.FAILURE),
+        (AssertionType.GT, 100.1, 100, settings.MONITOR.STATUS.SUCCESS),
+        (AssertionType.GT, 100, 100, settings.MONITOR.STATUS.FAILURE),
+        (AssertionType.GT, 101, 100, settings.MONITOR.STATUS.SUCCESS),
+        (AssertionType.GTE, 99, 100, settings.MONITOR.STATUS.FAILURE),
+        (AssertionType.GTE, 100, 100, settings.MONITOR.STATUS.SUCCESS),
+        (AssertionType.GTE, 101, 100, settings.MONITOR.STATUS.SUCCESS),
+        (AssertionType.LT, 99, 100, settings.MONITOR.STATUS.SUCCESS),
+        (AssertionType.LT, 99.9, 100, settings.MONITOR.STATUS.SUCCESS),
+        (AssertionType.LT, 100, 100, settings.MONITOR.STATUS.FAILURE),
+        (AssertionType.LT, 101, 100, settings.MONITOR.STATUS.FAILURE),
+        (AssertionType.LTE, 99, 100, settings.MONITOR.STATUS.SUCCESS),
+        (AssertionType.LTE, 100, 100, settings.MONITOR.STATUS.SUCCESS),
+        (AssertionType.LTE, 101, 100, settings.MONITOR.STATUS.FAILURE),
+    ],
+)
+def test_base_stat_monitor_assertion_types(
+    make_data, assertion_type, stat_value, threshold, expected_status
+):
+    class TestBaseStatMonitor(BaseStatMonitor):
+        stat_name = "test_statistic"
+        threshold_setting = "THRESHOLD_SETTING"
+        assert_type = assertion_type
+
+    data = make_data({TestBaseStatMonitor.threshold_setting: threshold})
+    runner = data.pop("runner")
+    data["stats"][TestBaseStatMonitor.stat_name] = stat_value
+    monitor_suite = MonitorSuite(monitors=[TestBaseStatMonitor])
+
+    runner.run(monitor_suite, **data)
+    assert runner.result.monitor_results[0].status == expected_status
+
+
+def test_base_stat_monitor_raise_not_configured_if_setting_not_provided(make_data):
+    class TestBaseStatMonitor(BaseStatMonitor):
+        stat_name = "test_statistic"
+        threshold_setting = "THRESHOLD_SETTING"
+        assert_type = AssertionType.LT
+
+    data = make_data()
+    runner = data.pop("runner")
+    data["stats"][TestBaseStatMonitor.stat_name] = 100
+    monitor_suite = MonitorSuite(monitors=[TestBaseStatMonitor])
+
+    with pytest.raises(NotConfigured):
+        runner.run(monitor_suite, **data)
+
+
+def test_not_configured_without_threshold_setting_or_method(make_data):
+    class TestBaseStatMonitor(BaseStatMonitor):
+        stat_name = "test_statistic"
+        assert_type = AssertionType.EQ
+
+    data = make_data()
+    runner = data.pop("runner")
+    data["stats"][TestBaseStatMonitor.stat_name] = 100
+    monitor_suite = MonitorSuite(monitors=[TestBaseStatMonitor])
+
+    with pytest.raises(NotConfigured):
+        runner.run(monitor_suite, **data)
+
+
+def test_base_stat_monitor_using_get_threshold_method(make_data):
+    class TestBaseStatMonitor(BaseStatMonitor):
+        stat_name = "test_statistic"
+        assert_type = AssertionType.EQ
+
+        def get_threshold(self):
+            return 100
+
+    data = make_data()
+    runner = data.pop("runner")
+    data["stats"][TestBaseStatMonitor.stat_name] = 100
+    monitor_suite = MonitorSuite(monitors=[TestBaseStatMonitor])
+
+    runner.run(monitor_suite, **data)
+    assert runner.result.monitor_results[0].status == settings.MONITOR.STATUS.SUCCESS
+
+
+def test_failure_message_describe_values_expected(make_data):
+    class TestBaseStatMonitor(BaseStatMonitor):
+        stat_name = "test_statistic"
+        threshold_setting = "THRESHOLD_SETTING"
+        assert_type = AssertionType.EQ
+
+    expected_threshold = 100
+    obtained_value = 90
+    data = make_data({TestBaseStatMonitor.threshold_setting: expected_threshold})
+
+    runner = data.pop("runner")
+    data["stats"][TestBaseStatMonitor.stat_name] = obtained_value
+    monitor_suite = MonitorSuite(monitors=[TestBaseStatMonitor])
+
+    runner.run(monitor_suite, **data)
+    assert (
+        runner.result.monitor_results[0].reason
+        == f"'{TestBaseStatMonitor.stat_name}' - expected: {TestBaseStatMonitor.assert_type.value}"
+        f" to {expected_threshold} - obtained: {obtained_value}",
+    )

--- a/tests/contrib/scrapy/monitors/test_base_stat_monitor.py
+++ b/tests/contrib/scrapy/monitors/test_base_stat_monitor.py
@@ -1,7 +1,6 @@
 import pytest
 from spidermon.contrib.scrapy.monitors import (
     BaseStatMonitor,
-    AssertionType,
 )
 from spidermon import MonitorSuite
 from spidermon.exceptions import NotConfigured
@@ -11,26 +10,26 @@ from spidermon import settings
 @pytest.mark.parametrize(
     "assertion_type,stat_value,threshold,expected_status",
     [
-        (AssertionType.EQ, 90, 100, settings.MONITOR.STATUS.FAILURE),
-        (AssertionType.EQ, 100, 100, settings.MONITOR.STATUS.SUCCESS),
-        (AssertionType.EQ, 110, 100, settings.MONITOR.STATUS.FAILURE),
-        (AssertionType.NEQ, 90, 100, settings.MONITOR.STATUS.SUCCESS),
-        (AssertionType.NEQ, 100, 100, settings.MONITOR.STATUS.FAILURE),
-        (AssertionType.NEQ, 110, 100, settings.MONITOR.STATUS.SUCCESS),
-        (AssertionType.GT, 99, 100, settings.MONITOR.STATUS.FAILURE),
-        (AssertionType.GT, 100.1, 100, settings.MONITOR.STATUS.SUCCESS),
-        (AssertionType.GT, 100, 100, settings.MONITOR.STATUS.FAILURE),
-        (AssertionType.GT, 101, 100, settings.MONITOR.STATUS.SUCCESS),
-        (AssertionType.GTE, 99, 100, settings.MONITOR.STATUS.FAILURE),
-        (AssertionType.GTE, 100, 100, settings.MONITOR.STATUS.SUCCESS),
-        (AssertionType.GTE, 101, 100, settings.MONITOR.STATUS.SUCCESS),
-        (AssertionType.LT, 99, 100, settings.MONITOR.STATUS.SUCCESS),
-        (AssertionType.LT, 99.9, 100, settings.MONITOR.STATUS.SUCCESS),
-        (AssertionType.LT, 100, 100, settings.MONITOR.STATUS.FAILURE),
-        (AssertionType.LT, 101, 100, settings.MONITOR.STATUS.FAILURE),
-        (AssertionType.LTE, 99, 100, settings.MONITOR.STATUS.SUCCESS),
-        (AssertionType.LTE, 100, 100, settings.MONITOR.STATUS.SUCCESS),
-        (AssertionType.LTE, 101, 100, settings.MONITOR.STATUS.FAILURE),
+        ("==", 90, 100, settings.MONITOR.STATUS.FAILURE),
+        ("==", 100, 100, settings.MONITOR.STATUS.SUCCESS),
+        ("==", 110, 100, settings.MONITOR.STATUS.FAILURE),
+        ("!=", 90, 100, settings.MONITOR.STATUS.SUCCESS),
+        ("!=", 100, 100, settings.MONITOR.STATUS.FAILURE),
+        ("!=", 110, 100, settings.MONITOR.STATUS.SUCCESS),
+        (">", 99, 100, settings.MONITOR.STATUS.FAILURE),
+        (">", 100.1, 100, settings.MONITOR.STATUS.SUCCESS),
+        (">", 100, 100, settings.MONITOR.STATUS.FAILURE),
+        (">", 101, 100, settings.MONITOR.STATUS.SUCCESS),
+        (">=", 99, 100, settings.MONITOR.STATUS.FAILURE),
+        (">=", 100, 100, settings.MONITOR.STATUS.SUCCESS),
+        (">=", 101, 100, settings.MONITOR.STATUS.SUCCESS),
+        ("<", 99, 100, settings.MONITOR.STATUS.SUCCESS),
+        ("<", 99.9, 100, settings.MONITOR.STATUS.SUCCESS),
+        ("<", 100, 100, settings.MONITOR.STATUS.FAILURE),
+        ("<", 101, 100, settings.MONITOR.STATUS.FAILURE),
+        ("<=", 99, 100, settings.MONITOR.STATUS.SUCCESS),
+        ("<=", 100, 100, settings.MONITOR.STATUS.SUCCESS),
+        ("<=", 101, 100, settings.MONITOR.STATUS.FAILURE),
     ],
 )
 def test_base_stat_monitor_assertion_types(
@@ -54,7 +53,7 @@ def test_base_stat_monitor_raise_not_configured_if_setting_not_provided(make_dat
     class TestBaseStatMonitor(BaseStatMonitor):
         stat_name = "test_statistic"
         threshold_setting = "THRESHOLD_SETTING"
-        assert_type = AssertionType.LT
+        assert_type = "<"
 
     data = make_data()
     runner = data.pop("runner")
@@ -68,7 +67,7 @@ def test_base_stat_monitor_raise_not_configured_if_setting_not_provided(make_dat
 def test_not_configured_without_threshold_setting_or_method(make_data):
     class TestBaseStatMonitor(BaseStatMonitor):
         stat_name = "test_statistic"
-        assert_type = AssertionType.EQ
+        assert_type = "=="
 
     data = make_data()
     runner = data.pop("runner")
@@ -82,7 +81,7 @@ def test_not_configured_without_threshold_setting_or_method(make_data):
 def test_base_stat_monitor_using_get_threshold_method(make_data):
     class TestBaseStatMonitor(BaseStatMonitor):
         stat_name = "test_statistic"
-        assert_type = AssertionType.EQ
+        assert_type = "=="
 
         def get_threshold(self):
             return 100
@@ -100,7 +99,7 @@ def test_failure_message_describe_values_expected(make_data):
     class TestBaseStatMonitor(BaseStatMonitor):
         stat_name = "test_statistic"
         threshold_setting = "THRESHOLD_SETTING"
-        assert_type = AssertionType.EQ
+        assert_type = "=="
 
     expected_threshold = 100
     obtained_value = 90
@@ -113,6 +112,6 @@ def test_failure_message_describe_values_expected(make_data):
     runner.run(monitor_suite, **data)
     assert (
         runner.result.monitor_results[0].reason
-        == f"'{TestBaseStatMonitor.stat_name}' - expected: {TestBaseStatMonitor.assert_type.value}"
-        f" to {expected_threshold} - obtained: {obtained_value}",
+        == f"Expecting '{TestBaseStatMonitor.stat_name}' to be '{TestBaseStatMonitor.assert_type}' "
+        f"to '{expected_threshold}'. Current value: '{obtained_value}'",
     )


### PR DESCRIPTION
Solves #321 

This PR includes a easier way to create custom monitors based on simple comparisons between a job stat and a threshold. We are talking usually about numerical values, but for EQUAL and NOTEQUAL, this can be strings as well.

A monitor that checks if a stat called `test_stat` is greater than or equal to a value defined in a project setting called `TEST_STAT_THRESHOLD`can be defined as follows:

```
    class TestStatMonitor(BaseStatMonitor):
        stat_name = "test_stat"
        threshold_setting = "TEST_STAT_THRESHOLD"
        assert_type = AssertionType.GTE
```

The threshold value can also be defined by a method, so we are able to create more complex rules to define what the threshold should be. Some ideas that can be accomplished using that method:
* Compare the number of items returned with the number of the latest job
* Define the threshold as a percentage of the number of input URLs against the number of requests
* etc

```
    class TestStatMonitor(BaseStatMonitor):
        stat_name = "test_stat"
        assert_type = AssertionType.GTE

        def get_threshold(self):
            # Do something to get the value
            return threshold
```

We still need to add the docs for this new feature and rewrite most of the built-in monitors to use this new structure.