### PR TITLE
[PeriodicExecutionTimeMonitor] Using utcnow and comparing to spider start as dt

### DIFF
--- a/spidermon/contrib/scrapy/monitors.py
+++ b/spidermon/contrib/scrapy/monitors.py
@@ -511,13 +511,12 @@ class PeriodicExecutionTimeMonitor(Monitor, StatsMonitorMixin):
         max_execution_time = crawler.settings.getint(SPIDERMON_MAX_EXECUTION_TIME)
         if not max_execution_time:
             return
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
         start_time = self.data.stats.get("start_time")
         if not start_time:
             return
 
-        start_dt = datetime.datetime.fromtimestamp(start_time / 1000)
-        duration = now - start_dt
+        duration = now - start_time
 
         msg = "The job has exceeded the maximum execution time"
         self.assertLess(duration.total_seconds(), max_execution_time, msg=msg)

--- a/tests/contrib/scrapy/monitors/test_periodic_execution_time_monitor.py
+++ b/tests/contrib/scrapy/monitors/test_periodic_execution_time_monitor.py
@@ -7,6 +7,9 @@ from spidermon.contrib.scrapy.monitors import (
 )
 from spidermon import MonitorSuite
 
+# For these tests we treat it as though spider has been running 100 seconds
+FAKE_EXECUTION_TIME = 100
+FAKE_START_TS = 1632834644
 
 @pytest.fixture
 def monitor_suite():
@@ -23,26 +26,22 @@ def mock_spider():
 
 @pytest.fixture
 def mock_datetime(mocker):
-    return mocker.patch("spidermon.contrib.scrapy.monitors.datetime")
+    mocked_datetime = mocker.patch("spidermon.contrib.scrapy.monitors.datetime")
+    fake_now_dt = datetime.datetime.fromtimestamp(FAKE_START_TS + FAKE_EXECUTION_TIME)
+
+    mocked_datetime.datetime.utcnow.return_value = fake_now_dt
+    return mocked_datetime
 
 
 def test_periodic_execution_monitor_should_fail(
-    make_data, monitor_suite, mock_spider, mock_datetime
+    make_data, mock_datetime, monitor_suite, mock_spider,
 ):
     """PeriodicExecutionTimeMonitor should fail if start time was too long ago"""
-    fake_execution_time = 100
-    fake_now_ts = 1632834644
-    fake_now_dt = datetime.datetime.fromtimestamp(fake_now_ts)
-    fake_start_time_ts = fake_now_ts - fake_execution_time
-
-    mock_datetime.datetime.now.return_value = fake_now_dt
-    mock_datetime.datetime.fromtimestamp = datetime.datetime.fromtimestamp
-
-    data = make_data({SPIDERMON_MAX_EXECUTION_TIME: fake_execution_time})
+    data = make_data({SPIDERMON_MAX_EXECUTION_TIME: FAKE_EXECUTION_TIME - 1})
     runner = data.pop("runner")
-    data["crawler"].stats.set_value("start_time", fake_start_time_ts * 1000)
     data["crawler"].spider = mock_spider
-    error_expected = "AssertionError: 100.0 not less than 100 : The job has exceeded the maximum execution time"
+    data["crawler"].stats.set_value("start_time", datetime.datetime.fromtimestamp(FAKE_START_TS))
+    error_expected = "AssertionError: 100.0 not less than 99 : The job has exceeded the maximum execution time"
 
     runner.run(monitor_suite, **data)
     for r in runner.result.monitor_results:
@@ -50,21 +49,14 @@ def test_periodic_execution_monitor_should_fail(
 
 
 def test_periodic_execution_monitor_should_pass(
-    make_data, monitor_suite, mock_spider, mock_datetime
+    make_data, mock_datetime, monitor_suite, mock_spider,
 ):
     """PeriodicExecutionTimeMonitor should pass if start time was not too long ago"""
-    fake_execution_time = 100
-    fake_now_ts = 1632834644
-    fake_now_dt = datetime.datetime.fromtimestamp(fake_now_ts)
-    fake_start_time_ts = fake_now_ts - fake_execution_time
 
-    mock_datetime.datetime.now.return_value = fake_now_dt
-    mock_datetime.datetime.fromtimestamp = datetime.datetime.fromtimestamp
-
-    data = make_data({SPIDERMON_MAX_EXECUTION_TIME: fake_execution_time + 1})
+    data = make_data({SPIDERMON_MAX_EXECUTION_TIME: FAKE_EXECUTION_TIME + 1})
     runner = data.pop("runner")
-    data["crawler"].stats.set_value("start_time", fake_start_time_ts * 1000)
     data["crawler"].spider = mock_spider
+    data["crawler"].stats.set_value("start_time", datetime.datetime.fromtimestamp(FAKE_START_TS))
 
     runner.run(monitor_suite, **data)
     for r in runner.result.monitor_results:
@@ -72,7 +64,7 @@ def test_periodic_execution_monitor_should_pass(
 
 
 def test_periodic_execution_monitor_not_set(make_data, monitor_suite, mock_spider):
-    """PeriodicExecutionTimeMonitor should fail if start time was too long ago"""
+    """PeriodicExecutionTimeMonitor should do nothing if threshold not set"""
     data = make_data()
     runner = data.pop("runner")
     runner.run(monitor_suite, **data)

--- a/tests/contrib/scrapy/monitors/test_periodic_execution_time_monitor.py
+++ b/tests/contrib/scrapy/monitors/test_periodic_execution_time_monitor.py
@@ -11,6 +11,7 @@ from spidermon import MonitorSuite
 FAKE_EXECUTION_TIME = 100
 FAKE_START_TS = 1632834644
 
+
 @pytest.fixture
 def monitor_suite():
     return MonitorSuite(monitors=[PeriodicExecutionTimeMonitor])
@@ -34,13 +35,18 @@ def mock_datetime(mocker):
 
 
 def test_periodic_execution_monitor_should_fail(
-    make_data, mock_datetime, monitor_suite, mock_spider,
+    make_data,
+    mock_datetime,
+    monitor_suite,
+    mock_spider,
 ):
     """PeriodicExecutionTimeMonitor should fail if start time was too long ago"""
     data = make_data({SPIDERMON_MAX_EXECUTION_TIME: FAKE_EXECUTION_TIME - 1})
     runner = data.pop("runner")
     data["crawler"].spider = mock_spider
-    data["crawler"].stats.set_value("start_time", datetime.datetime.fromtimestamp(FAKE_START_TS))
+    data["crawler"].stats.set_value(
+        "start_time", datetime.datetime.fromtimestamp(FAKE_START_TS)
+    )
     error_expected = "AssertionError: 100.0 not less than 99 : The job has exceeded the maximum execution time"
 
     runner.run(monitor_suite, **data)
@@ -49,14 +55,19 @@ def test_periodic_execution_monitor_should_fail(
 
 
 def test_periodic_execution_monitor_should_pass(
-    make_data, mock_datetime, monitor_suite, mock_spider,
+    make_data,
+    mock_datetime,
+    monitor_suite,
+    mock_spider,
 ):
     """PeriodicExecutionTimeMonitor should pass if start time was not too long ago"""
 
     data = make_data({SPIDERMON_MAX_EXECUTION_TIME: FAKE_EXECUTION_TIME + 1})
     runner = data.pop("runner")
     data["crawler"].spider = mock_spider
-    data["crawler"].stats.set_value("start_time", datetime.datetime.fromtimestamp(FAKE_START_TS))
+    data["crawler"].stats.set_value(
+        "start_time", datetime.datetime.fromtimestamp(FAKE_START_TS)
+    )
 
     runner.run(monitor_suite, **data)
     for r in runner.result.monitor_results:


### PR DESCRIPTION
Fixing issue where it checks unix timestamp instead of datetime retrieved via utcnow. Reported in original PR after merge - https://github.com/scrapinghub/spidermon/pull/309