### PR TITLE
Use BaseStatMonitor to implement built-in downloader exception monitor

### DIFF
--- a/tests/contrib/scrapy/monitors/test_downloader_exception_monitor.py
+++ b/tests/contrib/scrapy/monitors/test_downloader_exception_monitor.py
@@ -1,55 +1,48 @@
+import pytest
+
 from spidermon.contrib.scrapy.monitors import (
     DownloaderExceptionMonitor,
-    SPIDERMON_MAX_DOWNLOADER_EXCEPTIONS,
 )
 from spidermon import MonitorSuite
+from spidermon.exceptions import NotConfigured
+from spidermon import settings
 
 
-def new_suite():
+@pytest.fixture
+def downloader_exception_suite():
     return MonitorSuite(monitors=[DownloaderExceptionMonitor])
 
 
-def test_downloader_exception_monitor_should_fail(make_data):
-    """Downloader Exceptions should fail if the downloader exceptions count is higher than expected"""
-
-    data = make_data({SPIDERMON_MAX_DOWNLOADER_EXCEPTIONS: 10})
-    runner = data.pop("runner")
-    suite = new_suite()
-    data["stats"]["downloader/exception_count"] = 12
-    runner.run(suite, **data)
-    assert (
-        "Too many downloader exceptions (12)" in runner.result.monitor_results[0].error
-    )
-
-
-def test_downloader_exception_monitor_should_pass_disabled(make_data):
-    """Downloader Exceptions should pass if the limit is negative"""
-
-    data = make_data({SPIDERMON_MAX_DOWNLOADER_EXCEPTIONS: -1})
-    runner = data.pop("runner")
-    suite = new_suite()
-    data["stats"]["downloader/exception_count"] = 99999
-    runner.run(suite, **data)
-    assert runner.result.monitor_results[0].error is None
-
-
-def test_downloader_exception_monitor_should_pass_default(make_data):
-    """Downloader Exceptions should pass if the limit is not set"""
-
+def test_needs_to_configure_downloader_exception_monitor(
+    make_data, downloader_exception_suite
+):
     data = make_data()
     runner = data.pop("runner")
-    suite = new_suite()
-    data["stats"]["downloader/exception_count"] = 99999
-    runner.run(suite, **data)
-    assert runner.result.monitor_results[0].error is None
+    data["crawler"].stats.set_value(DownloaderExceptionMonitor.stat_name, 10)
+    with pytest.raises(NotConfigured):
+        runner.run(downloader_exception_suite, **data)
 
 
-def test_downloader_exception_monitor_should_pass_under_limit(make_data):
-    """Downloader Exceptions should pass if the downloader exceptions count is not higher than expected"""
-
-    data = make_data({SPIDERMON_MAX_DOWNLOADER_EXCEPTIONS: 10})
+@pytest.mark.parametrize(
+    "value,threshold,expected_status",
+    [
+        (0, 100, settings.MONITOR.STATUS.SUCCESS),
+        (50, 100, settings.MONITOR.STATUS.SUCCESS),
+        (99, 100, settings.MONITOR.STATUS.SUCCESS),
+        (100, 100, settings.MONITOR.STATUS.SUCCESS),
+        (101, 100, settings.MONITOR.STATUS.FAILURE),
+        (1000, 1, settings.MONITOR.STATUS.FAILURE),
+    ],
+)
+def test_downloader_exception_monitor_validation(
+    make_data, downloader_exception_suite, value, threshold, expected_status
+):
+    data = make_data({DownloaderExceptionMonitor.threshold_setting: threshold})
     runner = data.pop("runner")
-    suite = new_suite()
-    data["stats"]["downloader/exception_count"] = 3
-    runner.run(suite, **data)
-    assert runner.result.monitor_results[0].error is None
+
+    data["stats"][DownloaderExceptionMonitor.stat_name] = value
+
+    runner.run(downloader_exception_suite, **data)
+
+    assert len(runner.result.monitor_results) == 1
+    assert runner.result.monitor_results[0].status == expected_status


### PR DESCRIPTION
All built-in monitors should use `BaseStatMonitor` when possible. So this PR will continue converting them. Also improving the documentation with a bit more details about the monitor.