### PR TITLE
Skipped monitor for downloader exception

### DIFF
--- a/spidermon/contrib/scrapy/monitors.py
+++ b/spidermon/contrib/scrapy/monitors.py
@@ -109,7 +109,7 @@ class BaseStatMonitor(BaseScrapyMonitor):
             and self.threshold_setting not in self.crawler.settings.attributes
         ):
             raise NotConfigured(
-                f"Configure {self.threshold_setting} to your project"
+                f"Configure {self.threshold_setting} to your project "
                 f"settings to use {self.monitor_name}."
             )
 

--- a/spidermon/contrib/scrapy/monitors.py
+++ b/spidermon/contrib/scrapy/monitors.py
@@ -308,7 +308,7 @@ class DownloaderExceptionMonitor(BaseStatMonitor):
     This amount is provided by ``downloader/exception_count``
     value of your job statistics. If the value is not available
     in the statistics (i.e., no exception was raised), the monitor
-    will pass.
+    will be skipped.
 
     Configure the threshold using the ``SPIDERMON_MAX_DOWNLOADER_EXCEPTIONS``
     setting. There's **NO** default value for this setting.


### PR DESCRIPTION
Fixed documentation and add test for the scenario when the stat is not available because no exception was raised. Also fixed a missing white space that made the error message has two strings concatenated.