### PR TITLE
Fix "ModuleNotFoundError" when running spider outside Scrapy Cloud

### DIFF
--- a/spidermon/contrib/scrapy/extensions.py
+++ b/spidermon/contrib/scrapy/extensions.py
@@ -8,7 +8,6 @@ from spidermon.contrib.scrapy.runners import SpiderMonitorRunner
 from spidermon.python import factory
 from spidermon.python.monitors import ExpressionsMonitor
 from spidermon.utils.field_coverage import calculate_field_coverage
-from spidermon.utils.hubstorage import hs
 
 
 class Spidermon:
@@ -172,6 +171,8 @@ class Spidermon:
             runner.run(suite, **data)
 
     def _generate_data_for_spider(self, spider):
+        from spidermon.utils.hubstorage import hs
+
         return {
             "stats": self.crawler.stats.get_stats(spider),
             "stats_history": spider.stats_history

--- a/spidermon/utils/hubstorage.py
+++ b/spidermon/utils/hubstorage.py
@@ -5,9 +5,6 @@ import os
 from codecs import decode
 
 
-from scrapinghub import HubstorageClient
-
-
 class _Hubstorage:
     def __init__(self):
         self.available = "SHUB_JOBKEY" in os.environ
@@ -46,6 +43,8 @@ class _Hubstorage:
 
     @property
     def client(self):
+        from scrapinghub import HubstorageClient
+
         if self._client is None:
             self._client = HubstorageClient(endpoint=self.endpoint, auth=self.auth)
         return self._client


### PR DESCRIPTION
This PR fixes #340 .