### PR TITLE
Allow Arbitrary kwargs when sending Slack messages using the slack Client postMessage method

### DIFF
--- a/spidermon/contrib/actions/slack/__init__.py
+++ b/spidermon/contrib/actions/slack/__init__.py
@@ -108,7 +108,7 @@ class SlackMessageManager:
             )
 
     def _send_channel_message(
-        self, channel, text, parse="full", link_names=1, attachments=None
+        self, channel, text, parse="full", link_names=1, attachments=None, **kwargs
     ):
         self._client.chat_postMessage(
             channel=channel,
@@ -118,6 +118,7 @@ class SlackMessageManager:
             attachments=self._parse_attachments(attachments),
             username=self.sender_name,
             icon_url=self._get_icon_url(),
+            **kwargs,
         )
 
     def _get_icon_url(self):

--- a/spidermon/contrib/actions/slack/__init__.py
+++ b/spidermon/contrib/actions/slack/__init__.py
@@ -39,7 +39,8 @@ class SlackMessageManager:
         return self._users
 
     def send_message(
-        self, to, text, parse=None, link_names=1, attachments=None, use_mention=False
+        self, to, text, parse=None, link_names=1, attachments=None, use_mention=False,
+        **kwargs,
     ):
         if self.fake:
             logger.info(text)
@@ -56,6 +57,7 @@ class SlackMessageManager:
                     link_names=link_names,
                     attachments=attachments,
                     use_mention=use_mention,
+                    **kwargs,
                 )
                 for recipient in to
             ]
@@ -66,6 +68,7 @@ class SlackMessageManager:
                 parse=parse,
                 link_names=link_names,
                 attachments=attachments,
+                **kwargs,
             )
         else:
             if use_mention:
@@ -79,6 +82,7 @@ class SlackMessageManager:
                 parse=parse,
                 link_names=link_names,
                 attachments=attachments,
+                **kwargs,
             )
 
     def _get_user_id(self, username):
@@ -95,7 +99,7 @@ class SlackMessageManager:
         )
 
     def _send_user_message(
-        self, username, text, parse="full", link_names=1, attachments=None
+        self, username, text, parse="full", link_names=1, attachments=None, **kwargs,
     ):
         user_id = self._get_user_id(username)
         if user_id:
@@ -105,10 +109,11 @@ class SlackMessageManager:
                 parse=parse,
                 link_names=link_names,
                 attachments=attachments,
+                **kwargs,
             )
 
     def _send_channel_message(
-        self, channel, text, parse="full", link_names=1, attachments=None, **kwargs
+        self, channel, text, parse="full", link_names=1, attachments=None, **kwargs,
     ):
         self._client.chat_postMessage(
             channel=channel,

--- a/tests/contrib/actions/slack/test_slack_action.py
+++ b/tests/contrib/actions/slack/test_slack_action.py
@@ -1,5 +1,6 @@
 import sys
 import pytest
+from unittest.mock import MagicMock
 
 from spidermon.contrib.actions.slack import SlackMessageManager
 
@@ -58,3 +59,35 @@ def test_do_not_log_text_and_attach_when_fake_is_not_set(logger_info):
     )
 
     assert logger_info.call_count == 0
+
+def test_pass_arbitrary_kwargs_to_send_message():
+    manager = SlackMessageManager(
+        sender_token="anything", sender_name="@someone", 
+    )
+    manager.send_message = MagicMock()
+    manager.send_message(
+        to=[], text='some_text', reply_broadcast=True,
+        thread_ts='some_thread_ts_value',
+        unfurl_links=False,
+    )
+    manager.send_message.assert_called_once_with(
+        to=[], text='some_text', reply_broadcast=True,
+        thread_ts='some_thread_ts_value',
+        unfurl_links=False,
+    )
+
+def test_pass_arbitrary_kwargs_to_chat_postMessage():
+    manager = SlackMessageManager(
+        sender_token="anything", sender_name="@someone", 
+    )
+    manager._client.chat_postMessage = MagicMock()
+    manager._client.chat_postMessage(
+        to=[], text='some_text', reply_broadcast=True,
+        thread_ts='some_thread_ts_value',
+        unfurl_links=False,
+    )
+    manager._client.chat_postMessage.assert_called_once_with(
+        to=[], text='some_text', reply_broadcast=True,
+        thread_ts='some_thread_ts_value',
+        unfurl_links=False,
+    )


### PR DESCRIPTION
Resolves #293