### PR TITLE
Fix Sphinx 5 warning by setting docs language

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ release = ""
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Introduced in Sphinx 5.x:
https://github.com/sphinx-doc/sphinx/issues/10062

We need to define a language in our conf.py