### PR TITLE
Improve not configured exception messages

### DIFF
--- a/spidermon/contrib/actions/discord/__init__.py
+++ b/spidermon/contrib/actions/discord/__init__.py
@@ -14,7 +14,9 @@ class DiscordMessageManager:
 
     def __init__(self, webhook_url, fake=False):
         if not webhook_url:
-            raise NotConfigured("You must provide a discord webhook URL.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_DISCORD_WEBHOOK_URL setting."
+            )
         self.webhook_url = webhook_url
         self.fake = fake
 

--- a/spidermon/contrib/actions/email/__init__.py
+++ b/spidermon/contrib/actions/email/__init__.py
@@ -39,7 +39,7 @@ class SendEmail(ActionWithTemplates):
         body_html_template=None,
         fake=None,
         *args,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.sender = sender or self.sender
@@ -56,14 +56,31 @@ class SendEmail(ActionWithTemplates):
         self.fake = fake or self.fake
         if not self.fake and not self.to:
             raise NotConfigured(
-                "You must provide at least one recipient for the message."
+                "You must provide a value for SPIDERMON_EMAIL_TO setting."
             )
         if not self.subject:
-            raise NotConfigured("You must provide a subject for the message.")
-        if not (
-            self.body_text or body_text_template or body_html or self.body_html_template
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_EMAIL_SUBJECT setting."
+            )
+        if not any(
+            [
+                self.body_text,
+                self.body_text_template,
+                self.body_html,
+                self.body_html_template,
+            ]
         ):
-            raise NotConfigured("You must provide a body for the message.")
+            body_settings = ", ".join(
+                [
+                    "SPIDERMON_BODY_TEXT",
+                    "SPIDERMON_BODY_TEXT_TEMPLATE",
+                    "SPIDERMON_BODY_HTML",
+                    "SPIDERMON_BODY_HTML_TEMPLATE",
+                ]
+            )
+            raise NotConfigured(
+                f"You must provide a value for one of these settings: {body_settings}"
+            )
 
     @classmethod
     def from_crawler_kwargs(cls, crawler):

--- a/spidermon/contrib/actions/email/ses.py
+++ b/spidermon/contrib/actions/email/ses.py
@@ -24,9 +24,13 @@ class SendSESEmail(SendEmail):
         self.aws_secret_key = aws_secret_key or self.aws_secret_key
         self.aws_region_name = aws_region_name or self.aws_region_name
         if not self.fake and not self.aws_access_key:
-            raise NotConfigured("You must provide the AWS Access Key.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_AWS_ACCESS_KEY_ID setting."
+            )
         if not self.fake and not self.aws_secret_key:
-            raise NotConfigured("You must provide the AWS Secret Key.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_AWS_SECRET_ACCESS_KEY setting."
+            )
 
     @classmethod
     def from_crawler_kwargs(cls, crawler):

--- a/spidermon/contrib/actions/reports/__init__.py
+++ b/spidermon/contrib/actions/reports/__init__.py
@@ -10,7 +10,9 @@ class CreateReport(ActionWithTemplates):
         self.template = template or self.template
         self.report = ""
         if not self.template:
-            raise NotConfigured("You must define one template file.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_REPORT_TEMPLATE setting."
+            )
 
     @classmethod
     def from_crawler_kwargs(cls, crawler):

--- a/spidermon/contrib/actions/reports/files.py
+++ b/spidermon/contrib/actions/reports/files.py
@@ -10,7 +10,9 @@ class CreateFileReport(CreateReport):
         super().__init__(*args, **kwargs)
         self.filename = filename or self.filename
         if not self.filename:
-            raise NotConfigured("You must define a template output file.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_REPORT_FILENAME setting."
+            )
 
     @classmethod
     def from_crawler_kwargs(cls, crawler):

--- a/spidermon/contrib/actions/reports/s3.py
+++ b/spidermon/contrib/actions/reports/s3.py
@@ -87,13 +87,21 @@ class CreateS3Report(CreateReport):
         self.make_public = make_public or self.make_public
         self.content_type = content_type or self.content_type
         if not self.aws_access_key:
-            raise NotConfigured("You must provide the AWS Access Key.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_AWS_ACCESS_KEY_ID setting."
+            )
         if not self.aws_secret_key:
-            raise NotConfigured("You must provide the AWS Secret Key.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_AWS_SECRET_ACCESS_KEY setting."
+            )
         if not self.s3_bucket:
-            raise NotConfigured("You must define the s3 bucket.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_REPORT_S3_BUCKET setting."
+            )
         if not self.s3_filename:
-            raise NotConfigured("You must define the s3 filename.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_REPORT_S3_FILENAME setting."
+            )
 
     @classmethod
     def from_crawler_kwargs(cls, crawler):

--- a/spidermon/contrib/actions/sentry/__init__.py
+++ b/spidermon/contrib/actions/sentry/__init__.py
@@ -35,10 +35,14 @@ class SendSentryMessage(Action):
         self.environment = environment or self.environment
 
         if not self.fake and not self.sentry_dsn:
-            raise NotConfigured("Missing SPIDERMON_SENTRY_DSN setting")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_SENTRY_DSN setting."
+            )
 
         if not self.project_name:
-            raise NotConfigured("Missing SPIDERMON_SENTRY_PROJECT_NAME setting")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_SENTRY_PROJECT_NAME setting."
+            )
 
     @classmethod
     def from_crawler_kwargs(cls, crawler):

--- a/spidermon/contrib/actions/slack/__init__.py
+++ b/spidermon/contrib/actions/slack/__init__.py
@@ -18,11 +18,15 @@ class SlackMessageManager:
     def __init__(self, sender_token=None, sender_name=None, fake=False):
         sender_token = sender_token or self.sender_token
         if not sender_token:
-            raise NotConfigured("You must provide a slack token.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_SLACK_SENDER_TOKEN setting."
+            )
 
         self.sender_name = sender_name or self.sender_name
         if not self.sender_name:
-            raise NotConfigured("You must provide a slack sender name.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_SLACK_SENDER_NAME setting."
+            )
 
         self.fake = fake
         self._client = WebClient(sender_token)
@@ -205,7 +209,7 @@ class SendSlackMessage(ActionWithTemplates):
 
         if not self.fake and not self.recipients:
             raise NotConfigured(
-                "You must provide at least one recipient for the message."
+                "You must provide a value for SPIDERMON_SLACK_RECIPIENTS setting."
             )
 
     @classmethod

--- a/spidermon/contrib/actions/telegram/__init__.py
+++ b/spidermon/contrib/actions/telegram/__init__.py
@@ -31,7 +31,9 @@ class TelegramMessageManager:
     def __init__(self, sender_token=None, fake=False):
         sender_token = sender_token or self.sender_token
         if not sender_token:
-            raise NotConfigured("You must provide a telegram bot token.")
+            raise NotConfigured(
+                "You must provide a value for SPIDERMON_TELEGRAM_SENDER_TOKEN setting."
+            )
 
         self.fake = fake
         self._client = SimplyTelegramClient(sender_token)
@@ -71,7 +73,7 @@ class SendTelegramMessage(ActionWithTemplates):
         self.message_template = message_template or self.message_template
         if not self.recipients:
             raise NotConfigured(
-                "You must provide at least one recipient for the message."
+                "You must provide a value for SPIDERMON_TELEGRAM_RECIPIENTS setting."
             )
 
     @classmethod


### PR DESCRIPTION
Improve messages making clear which setting should be defined to configure the failing action. This will help the users of the extension to easily identify how to configure the mandatory settings.