### PR TITLE
Add new feature to limit number of records in stats for SPIDERMON_ADD_FIELD_COVERAGE setting.

### DIFF
--- a/docs/source/actions/email-action.rst
+++ b/docs/source/actions/email-action.rst
@@ -146,6 +146,6 @@ SPIDERMON_EMAIL_SUBJECT_TEMPLATE
 --------------------------------
 
 .. _Amazon Simple Email Service: https://aws.amazon.com/pt/ses/
-.. _`AWS_ACCESS_KEY_ID`: https://docs.scrapy.org/en/latest/topics/settings.html#std:setting-AWS_ACCESS_KEY_ID
+.. _`AWS_ACCESS_KEY_ID`: https://docs.scrapy.org/en/latest/topics/settings.html#aws-access-key-id
 .. _`AWS_SECRET_ACCESS_KEY`: https://docs.scrapy.org/en/latest/topics/settings.html#aws-secret-access-key
 .. _Jinja2: http://jinja.pocoo.org/

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -142,7 +142,7 @@ field following this format:
       'spidermon_field_coverage/dict/field_1/nested_field_1_2': 0.5,
       'spidermon_item_scraped_count/dict/field_2': 0.5,
 
-SPIDERMON_LIMIT_FIELD_COVERAGE_BY_FIELD_COVERAGE_RULES
+SPIDERMON_FIELD_COVERAGE_SKIP_WITHOUT_FIELD_COVERAGE_RULES
 ----------------------------
 Default: ``False``
 

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -143,7 +143,7 @@ field following this format:
       'spidermon_item_scraped_count/dict/field_2': 0.5,
 
 SPIDERMON_FIELD_COVERAGE_SKIP_WITHOUT_FIELD_COVERAGE_RULES
-----------------------------
+----------------------------------------------------------
 Default: ``False``
 
 When enabled, Spidermon will add statistics about the number of items scraped and coverage only for fields that

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -142,6 +142,76 @@ field following this format:
       'spidermon_field_coverage/dict/field_1/nested_field_1_2': 0.5,
       'spidermon_item_scraped_count/dict/field_2': 0.5,
 
+SPIDERMON_LIMIT_FIELD_COVERAGE_BY_FIELD_COVERAGE_RULES
+----------------------------
+Default: ``False``
+
+When enabled, Spidermon will add statistics about the number of items scraped and coverage only for fields that
+exist in setting SPIDERMON_FIELD_COVERAGE_RULES in following format:
+
+``'spidermon_item_scraped_count/<item_type>/<field_name>': <item_count>``
+``'spidermon_field_coverage/<item_type>/<field_name>': <coverage>``
+
+Using this setting will help to limit number of records in statistic in case of huge number of fields (>500)
+in the item.
+
+.. note::
+
+   Nested fields are also supported. For example, if your spider returns these items:
+
+   .. code-block:: python
+
+      [
+        {
+          "field_1": {
+            "nested_field_1_1": "value",
+            "nested_field_1_2": "value",
+          },
+        },
+        {
+          "field_1": {
+            "nested_field_1_1": "value",
+          },
+          "field_2": "value"
+        },
+        {
+          "field_1": {
+            "nested_field_1_2": "value",
+          },
+          "field_2": "value"
+        },
+        {
+          "field_3": {
+            "nested_field_1_1": "value",
+          },
+        },
+      ]
+
+    and you have these rules:
+
+   .. code-block:: python
+
+    # project/settings.py
+    SPIDERMON_FIELD_COVERAGE_RULES = {
+        "dict/field_1": 0.75,
+        "dict/field_1/field_1_1": 0.5,
+        "dict/field_2": 1.0,
+    }
+
+
+   Statistics will be like the following (only includes fields from setting SPIDERMON_FIELD_COVERAGE_RULES):
+
+   .. code-block:: python
+
+      'spidermon_item_scraped_count/dict': 4,
+      'spidermon_item_scraped_count/dict/field_1': 3,
+      'spidermon_item_scraped_count/dict/field_1/nested_field_1_1': 2,
+      'spidermon_item_scraped_count/dict/field_2': 2,
+
+      'spidermon_field_coverage/dict/field_1': 0.75,
+      'spidermon_field_coverage/dict/field_1/nested_field_1_1': 0.5,
+      'spidermon_item_scraped_count/dict/field_2': 0.5,
+
 SPIDERMON_FIELD_COVERAGE_SKIP_NONE
 ----------------------------------
 Default: ``False``

--- a/spidermon/contrib/scrapy/extensions.py
+++ b/spidermon/contrib/scrapy/extensions.py
@@ -177,7 +177,7 @@ class Spidermon:
         skip_fields_without_rules = spider.crawler.settings.getbool(
             "SPIDERMON_FIELD_COVERAGE_SKIP_WITHOUT_FIELD_COVERAGE_RULES", False
         )
-        field_coverage_rules = spider.crawler.spider.settings.get(
+        field_coverage_rules = spider.crawler.settings.get(
             "SPIDERMON_FIELD_COVERAGE_RULES", {}
         )
         self.crawler.stats.inc_value("spidermon_item_scraped_count")

--- a/spidermon/contrib/scrapy/extensions.py
+++ b/spidermon/contrib/scrapy/extensions.py
@@ -132,7 +132,12 @@ class Spidermon:
         self._run_suites(spider, self.engine_stopped_suites)
 
     def _count_item(
-            self, item, skip_none_values, field_coverage_rules, skip_fields_without_rules, item_count_stat=None
+        self,
+        item,
+        skip_none_values,
+        field_coverage_rules,
+        skip_fields_without_rules,
+        item_count_stat=None,
     ):
         if item_count_stat is None:
             item_type = type(item).__name__
@@ -152,7 +157,11 @@ class Spidermon:
 
             if isinstance(value, dict):
                 self._count_item(
-                    value, skip_none_values, field_coverage_rules, skip_fields_without_rules, field_item_count_stat
+                    value,
+                    skip_none_values,
+                    field_coverage_rules,
+                    skip_fields_without_rules,
+                    field_item_count_stat,
                 )
                 continue
 
@@ -176,7 +185,9 @@ class Spidermon:
         if skip_fields_without_rules and not field_coverage_rules:
             return
 
-        self._count_item(item, skip_none_values, field_coverage_rules, skip_fields_without_rules)
+        self._count_item(
+            item, skip_none_values, field_coverage_rules, skip_fields_without_rules
+        )
 
     def _run_periodic_suites(self, spider, suites):
         suites = [self.load_suite(s) for s in suites]


### PR DESCRIPTION
In some cases, we have a huge number of fields in one item (>500). Enabling SPIDERMON_ADD_FIELD_COVERAGE adds a record for every field in stats and this raises the issue like "Value exceeds max encoded size of 65536 bytes" in Scrapy Cloud dashboard.

The idea is to limit the number of records in the stats to only fields that we actually want to monitor in SPIDERMON_FIELD_COVERAGE_RULES.



