### PR TITLE
Fix compatibility issues with jsonschema>=4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox codecov
       - name: Run tests
-        run: tox -e ${{ matrix.tox || "py" }}
+        run: tox -e ${{ matrix.tox || 'py' }}
       - name: Run docs and formatting tests
         if: ${{ matrix.python-version == 3.10 }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        include:
+        - python-version: "3.6"
+          tox: min
+        - python-version: "3.7"
+        - python-version: "3.8"
+        - python-version: "3.9"
+        - python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +31,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox codecov
       - name: Run tests
-        run: tox -e py
+        run: tox -e ${{ matrix.tox || "py" }}
       - name: Run docs and formatting tests
         if: ${{ matrix.python-version == 3.10 }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/source/howto/configuring-telegram-for-spidermon.rst
+++ b/docs/source/howto/configuring-telegram-for-spidermon.rst
@@ -14,7 +14,7 @@ send notifications to Telegram from Spidermon.
 Steps
 -----
 
-#. `Create a Telegram bot <https://core.telegram.org/bots#3-how-do-i-create-a-bot>`_.
+#. `Create a Telegram bot <https://core.telegram.org/bots#how-do-i-create-a-bot>`_.
 
 #. Once your bot is created, you will receive its Authorization Token. This `Bot Authorization Token` is what we use for ``SPIDERMON_TELEGRAM_SENDER_TOKEN``.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Jinja2
 slack-sdk
 boto
 premailer
-jsonschema[format]==3.2.0
+jsonschema[format]==4.0.0
 schematics==2.1.0
 python-slugify
 scrapy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Jinja2
 slack-sdk
 boto
 premailer
-jsonschema[format]==4.0.0
+jsonschema[format]
 schematics==2.1.0
 python-slugify
 scrapy

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     package_data={"spidermon": ["VERSION"]},
     zip_safe=False,
     include_package_data=True,
-    install_requires=["jsonschema[format]==4.0.0", "python-slugify"],
+    install_requires=["jsonschema[format]", "python-slugify"],
     tests_require=test_requirements,
     extras_require={
         # Specific monitors and tools to support notifications and reports

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     package_data={"spidermon": ["VERSION"]},
     zip_safe=False,
     include_package_data=True,
-    install_requires=["jsonschema[format]", "python-slugify"],
+    install_requires=["jsonschema[format]>=3.2.0", "python-slugify"],
     tests_require=test_requirements,
     extras_require={
         # Specific monitors and tools to support notifications and reports

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     package_data={"spidermon": ["VERSION"]},
     zip_safe=False,
     include_package_data=True,
-    install_requires=["jsonschema[format]==3.2.0", "python-slugify"],
+    install_requires=["jsonschema[format]==4.0.0", "python-slugify"],
     tests_require=test_requirements,
     extras_require={
         # Specific monitors and tools to support notifications and reports

--- a/spidermon/contrib/validation/jsonschema/formats.py
+++ b/spidermon/contrib/validation/jsonschema/formats.py
@@ -1,19 +1,18 @@
 from jsonschema._format import FormatChecker, _checks_drafts
-from jsonschema.compat import str_types
 
 from spidermon.contrib.validation.utils import is_valid_url, is_valid_email
 
 
 @_checks_drafts("url")
 def is_url(instance):
-    if not isinstance(instance, str_types):
+    if not isinstance(instance, str):
         return True
     return is_valid_url(instance)
 
 
 @_checks_drafts("email")
 def is_email(instance):
-    if not isinstance(instance, str_types):
+    if not isinstance(instance, str):
         return True
     return is_valid_email(instance)
 

--- a/spidermon/contrib/validation/jsonschema/translator.py
+++ b/spidermon/contrib/validation/jsonschema/translator.py
@@ -35,6 +35,7 @@ class JSONSchemaMessageTranslator(MessageTranslator):
         r"^.* is less than or equal to the minimum of .*$": messages.NUMBER_TOO_LOW,
         r"^.* is not a multiple of .*$": messages.NOT_MULTIPLE_OF,
         r"^.* should not be valid under .*$": messages.NOT_ALLOWED_VALUE,
+        r"^.* is not allowed for .*$": messages.NOT_ALLOWED_VALUE,
         r"^.+ is too short$": messages.FIELD_TOO_SHORT,
         r"^.+ is too long$": messages.FIELD_TOO_LONG,
         r"^.+ does not match .*$": messages.REGEX_NOT_MATCHED,

--- a/spidermon/contrib/validation/jsonschema/translator.py
+++ b/spidermon/contrib/validation/jsonschema/translator.py
@@ -34,7 +34,7 @@ class JSONSchemaMessageTranslator(MessageTranslator):
         r"^.* is less than the minimum of .*$": messages.NUMBER_TOO_LOW,
         r"^.* is less than or equal to the minimum of .*$": messages.NUMBER_TOO_LOW,
         r"^.* is not a multiple of .*$": messages.NOT_MULTIPLE_OF,
-        r"^.* is not allowed for .*$": messages.NOT_ALLOWED_VALUE,
+        r"^.* should not be valid under .*$": messages.NOT_ALLOWED_VALUE,
         r"^.+ is too short$": messages.FIELD_TOO_SHORT,
         r"^.+ is too long$": messages.FIELD_TOO_LONG,
         r"^.+ does not match .*$": messages.REGEX_NOT_MATCHED,

--- a/tests/test_validators_jsonschema.py
+++ b/tests/test_validators_jsonschema.py
@@ -37,6 +37,8 @@ class DataTest:
         self.valid = valid
         self.expected_errors = expected_errors or {}
         self.schema = schema
+        if isinstance(self.schema, dict) and not self.schema.get("$schema"):
+            self.schema["$schema"] = "http://json-schema.org/draft-07/schema#"
 
 
 class AdditionalItems(SchemaTest):
@@ -638,6 +640,9 @@ class Format(SchemaTest):
         ),
         DataTest(
             name="hostname. valid",
+            schema={
+                "$schema": "http://json-schema.org/draft-04/schema"
+            },
             data={
                 "hostnames": [
                     "localhost",

--- a/tests/test_validators_jsonschema.py
+++ b/tests/test_validators_jsonschema.py
@@ -640,9 +640,7 @@ class Format(SchemaTest):
         ),
         DataTest(
             name="hostname. valid",
-            schema={
-                "$schema": "http://json-schema.org/draft-04/schema"
-            },
+            schema={"$schema": "http://json-schema.org/draft-04/schema"},
             data={
                 "hostnames": [
                     "localhost",

--- a/tests/test_validators_jsonschema.py
+++ b/tests/test_validators_jsonschema.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 from spidermon.contrib.validation import JSONSchemaValidator
 from spidermon.contrib.validation import messages
+from spidermon.contrib.validation.jsonschema.formats import is_email, is_url
 
 from slugify import slugify
 
@@ -39,6 +40,19 @@ class DataTest:
         self.schema = schema
         if isinstance(self.schema, dict) and not self.schema.get("$schema"):
             self.schema["$schema"] = "http://json-schema.org/draft-07/schema#"
+
+
+class Formats(TestCase):
+    def test_is_email(self):
+        assert is_email(None)
+        assert is_email("mail@mail.com")
+        assert not is_email("not_mail")
+
+    def test_is_url(self):
+        assert is_url(None)
+        assert is_url("https://website.com")
+        assert not is_url("htttps://website.com")
+        assert not is_url("website.com")
 
 
 class AdditionalItems(SchemaTest):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = min,py37,py38,py39,py310
 skip_missing_interpreters = True
 
 [testenv]
@@ -7,6 +7,11 @@ extras =
     tests
     validation
 commands = pytest -s -W ignore::schematics.deprecated.SchematicsDeprecationWarning --cov=spidermon --cov-report= {posargs:tests}
+
+[testenv:min]
+basepython = python3.6
+deps =
+    jsonschema[format]==3.2.0
 
 [testenv:docs]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py{3.6,3.7,3.8,3.9}-jsonschema4
 skip_missing_interpreters = True
 
 [testenv]
+deps =
+    jsonschema4: jsonschema>=4.0.0,<5.0.0
 extras =
     tests
     validation

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,8 @@
 [tox]
-envlist = py{3.6,3.7,3.8,3.9}-jsonschema4
+envlist = py{3.6,3.7,3.8,3.9}
 skip_missing_interpreters = True
 
 [testenv]
-deps =
-    jsonschema4: jsonschema>=4.0.0,<5.0.0
 extras =
     tests
     validation

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.6,3.7,3.8,3.9}
+envlist = py36,py37,py38,py39,py310
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
I have managed to pass the tests after updating jsonschema. The only issue I have is that Python 3.6 is having dependency issues with jsonschema==4.

I'll try to make the changes compatible with both jsonschema4 and 3, so that Python3.6 is still compatible.