### PR TITLE
Allow to skip execution of FieldCoverageMonitor if no item is returned

### DIFF
--- a/spidermon/contrib/scrapy/monitors/monitors.py
+++ b/spidermon/contrib/scrapy/monitors/monitors.py
@@ -424,7 +424,7 @@ class FieldCoverageMonitor(BaseScrapyMonitor):
         return super().run(result)
 
     def test_check_if_field_coverage_rules_are_met(self):
-        skip_no_items = self.crawler.settings.get(
+        skip_no_items = self.crawler.settings.getbool(
             "SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM", False
         )
         items_scraped = self.data.stats.get("item_scraped_count", 0)

--- a/spidermon/contrib/scrapy/monitors/monitors.py
+++ b/spidermon/contrib/scrapy/monitors/monitors.py
@@ -424,8 +424,10 @@ class FieldCoverageMonitor(BaseScrapyMonitor):
         return super().run(result)
 
     def test_check_if_field_coverage_rules_are_met(self):
-        skip_no_items = self.crawler.settings.get('SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM', False)
-        items_scraped = self.data.stats.get('item_scraped_count', 0)
+        skip_no_items = self.crawler.settings.get(
+            "SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM", False
+        )
+        items_scraped = self.data.stats.get("item_scraped_count", 0)
         if skip_no_items and int(items_scraped) == 0:
             self.skipTest("No items were scraped.")
 

--- a/spidermon/contrib/scrapy/monitors/monitors.py
+++ b/spidermon/contrib/scrapy/monitors/monitors.py
@@ -417,6 +417,16 @@ class FieldCoverageMonitor(BaseScrapyMonitor):
             raise NotConfigured(
                 "To enable field coverage monitor, set SPIDERMON_ADD_FIELD_COVERAGE=True in your project settings"
             )
+
+        skip_no_items = self.crawler.settings.get('SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM', False)
+        items_scraped = self.data.stats.get('item_scraped_count', 0)
+        if skip_no_items and int(items_scraped) == 0:
+            msg = "[Spidermon] Skipped FieldCoverageMonitor because no items were scraped. " \
+                  "To avoid this skip, set SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM=False"
+            self.crawler.spider.logger.info(msg)
+
+            return
+
         return super().run(result)
 
     def test_check_if_field_coverage_rules_are_met(self):

--- a/spidermon/contrib/scrapy/monitors/monitors.py
+++ b/spidermon/contrib/scrapy/monitors/monitors.py
@@ -380,6 +380,9 @@ class FieldCoverageMonitor(BaseScrapyMonitor):
     You are not obligated to set rules for every field, just for the ones in which you are interested.
     Also, you can monitor nested fields if available in your returned items.
 
+    In case you have a job without items scraped, and you want to skip this test, you have to enable the
+    ``SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM`` setting to avoid the field coverage monitor error.
+
     .. warning::
 
        Rules for nested fields will be validated against the total number of items returned.
@@ -418,18 +421,14 @@ class FieldCoverageMonitor(BaseScrapyMonitor):
                 "To enable field coverage monitor, set SPIDERMON_ADD_FIELD_COVERAGE=True in your project settings"
             )
 
-        skip_no_items = self.crawler.settings.get('SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM', False)
-        items_scraped = self.data.stats.get('item_scraped_count', 0)
-        if skip_no_items and int(items_scraped) == 0:
-            msg = "[Spidermon] Skipped FieldCoverageMonitor because no items were scraped. " \
-                  "To avoid this skip, set SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM=False"
-            self.crawler.spider.logger.info(msg)
-
-            return
-
         return super().run(result)
 
     def test_check_if_field_coverage_rules_are_met(self):
+        skip_no_items = self.crawler.settings.get('SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM', False)
+        items_scraped = self.data.stats.get('item_scraped_count', 0)
+        if skip_no_items and int(items_scraped) == 0:
+            self.skipTest("No items were scraped.")
+
         failures = []
         field_coverage_rules = self.crawler.settings.getdict(
             "SPIDERMON_FIELD_COVERAGE_RULES"

--- a/tests/contrib/scrapy/test_monitors_field_coverage.py
+++ b/tests/contrib/scrapy/test_monitors_field_coverage.py
@@ -112,3 +112,34 @@ def test_monitor_pass_if_coverage_greater_than_expected(field_coverage_monitor_s
     monitor_runner.run(field_coverage_monitor_suite, **data)
 
     assert monitor_runner.result.wasSuccessful()
+
+
+def test_monitor_skip_if_no_items_set_true(field_coverage_monitor_suite):
+    settings = {
+        "SPIDERMON_ADD_FIELD_COVERAGE": True,
+        "SPIDERMON_FIELD_COVERAGE_RULES": {
+            "dict/field": 0.8,
+        },
+        'SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM': True
+    }
+    stats = {"item_scraped_count": 0}
+    data = make_data_for_monitor(settings=settings, stats=stats)
+    monitor_runner = data.pop("runner")
+    monitor_runner.run(field_coverage_monitor_suite, **data)
+
+    assert monitor_runner.result.wasSuccessful()
+
+
+def test_monitor_skip_if_no_items_set_false(field_coverage_monitor_suite):
+    settings = {
+        "SPIDERMON_ADD_FIELD_COVERAGE": True,
+        "SPIDERMON_FIELD_COVERAGE_RULES": {
+            "dict/field": 0.8,
+        },
+    }
+    stats = {"item_scraped_count": 0}
+    data = make_data_for_monitor(settings=settings, stats=stats)
+    monitor_runner = data.pop("runner")
+    monitor_runner.run(field_coverage_monitor_suite, **data)
+
+    assert not monitor_runner.result.wasSuccessful()

--- a/tests/contrib/scrapy/test_monitors_field_coverage.py
+++ b/tests/contrib/scrapy/test_monitors_field_coverage.py
@@ -120,7 +120,7 @@ def test_monitor_skip_if_no_items_set_true(field_coverage_monitor_suite):
         "SPIDERMON_FIELD_COVERAGE_RULES": {
             "dict/field": 0.8,
         },
-        "SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM": True
+        "SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM": True,
     }
     stats = {"item_scraped_count": 0}
     data = make_data_for_monitor(settings=settings, stats=stats)

--- a/tests/contrib/scrapy/test_monitors_field_coverage.py
+++ b/tests/contrib/scrapy/test_monitors_field_coverage.py
@@ -120,7 +120,7 @@ def test_monitor_skip_if_no_items_set_true(field_coverage_monitor_suite):
         "SPIDERMON_FIELD_COVERAGE_RULES": {
             "dict/field": 0.8,
         },
-        'SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM': True
+        "SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM": True
     }
     stats = {"item_scraped_count": 0}
     data = make_data_for_monitor(settings=settings, stats=stats)


### PR DESCRIPTION
Closes #366 

Added another setting called `SPIDERMON_FIELD_COVERAGE_SKIP_IF_NO_ITEM` for `FieldCoverageMonitor`:
- If this setting is enabled and we don't have any items scraped, it will not raise error anymore, it will send a message instead.