### PR TITLE
Change Ubuntu version on workflow settings.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Our pipeline hasn't been running for Python 3.6. This is due to an issue with github actions (https://github.com/actions/setup-python/issues/544). Fixing the ubuntu version to 20.04 should fix the problem according to the comments.