### PR TITLE
Update `BaseStatMonitor`'s `test_stat_monitor` to work with Scrapy Cloud

### DIFF
--- a/spidermon/contrib/scrapy/monitors.py
+++ b/spidermon/contrib/scrapy/monitors.py
@@ -38,8 +38,8 @@ class BaseStatMonitor(BaseScrapyMonitor):
 
     Create a monitor class inheriting from this class to have a custom
     monitor that validates numerical stats from your job execution
-    against a configurable threshold. If this threshold is set in Scrapy
-    Cloud (and not it the spider settings), the setting is read as a
+    against a configurable threshold. If this threshold is passed in
+    via command line arguments (and not it the spider settings), the setting is read as a
     string and converted to ``threshold_datatype`` type (default is
     float).
 

--- a/tests/contrib/scrapy/monitors/test_base_stat_monitor.py
+++ b/tests/contrib/scrapy/monitors/test_base_stat_monitor.py
@@ -166,3 +166,34 @@ def test_skipped_if_stat_can_not_be_found_but_monitor_configured_to_be_ignore(
 
     runner.run(monitor_suite, **data)
     assert runner.result.monitor_results[0].status == settings.MONITOR.STATUS.SKIPPED
+
+
+def test_base_stat_monitor_correctly_converts_string_thresholds_float(make_data):
+    class TestBaseStatMonitor(BaseStatMonitor):
+        stat_name = "test_statistic"
+        threshold_setting = "THRESHOLD_SETTING"
+        assert_type = ">="
+
+    data = make_data({"THRESHOLD_SETTING": "50.4"})
+    runner = data.pop("runner")
+    data["stats"][TestBaseStatMonitor.stat_name] = 50.5
+    monitor_suite = MonitorSuite(monitors=[TestBaseStatMonitor])
+
+    runner.run(monitor_suite, **data)
+    assert runner.result.monitor_results[0].status == settings.MONITOR.STATUS.SUCCESS
+
+
+def test_base_stat_monitor_correctly_converts_string_thresholds_int(make_data):
+    class TestBaseStatMonitor(BaseStatMonitor):
+        stat_name = "test_statistic"
+        threshold_setting = "THRESHOLD_SETTING"
+        assert_type = ">="
+        threshold_datatype = int
+
+    data = make_data({"THRESHOLD_SETTING": "50"})
+    runner = data.pop("runner")
+    data["stats"][TestBaseStatMonitor.stat_name] = 51
+    monitor_suite = MonitorSuite(monitors=[TestBaseStatMonitor])
+
+    runner.run(monitor_suite, **data)
+    assert runner.result.monitor_results[0].status == settings.MONITOR.STATUS.SUCCESS


### PR DESCRIPTION
Fixes #374.

When reading threshold values from the settings, the `BaseStatMonitor` [used ](https://github.com/scrapinghub/spidermon/pull/325/files#diff-9d830f5588694dea71ec34a158727c22a20d77630f7d8afd1705d966241ab00dR123) the `settings.get()` function. This works fine if the value is set in the project's settings as the data type is preserved when reading it. However, when getting the settings from a Scrapy Cloud project, using the bare `get()` function causes the value to be read as a string, which break comparisions.

The monitor was updated to use by default the `getfloat` function. A variable was added which allows setting the threshold data type (either `int` or `float`) along with a property that picks the correct _get_ function depending on the data type.

Two new unit tests were added to test for the cases where the values are actual strings.

Despite there being other monitors that inherit from BaseStatMonitor, no further changes were necessary as they'll benefit from the default `getfloat()` function.