### PR TITLE
round the actual coverage to 2 decimal pieces

### DIFF
--- a/spidermon/contrib/scrapy/monitors/monitors.py
+++ b/spidermon/contrib/scrapy/monitors/monitors.py
@@ -459,9 +459,9 @@ class FieldCoverageMonitor(BaseScrapyMonitor):
             "SPIDERMON_FIELD_COVERAGE_RULES"
         )
         for field, expected_coverage in field_coverage_rules.items():
-            actual_coverage = round(self.data.stats.get(
-                f"spidermon_field_coverage/{field}", 0
-            ),2)
+            actual_coverage = round(
+                self.data.stats.get(f"spidermon_field_coverage/{field}", 0), 2
+            )
             if actual_coverage < expected_coverage:
                 failures.append(
                     "{} (expected {}, got {})".format(

--- a/spidermon/contrib/scrapy/monitors/monitors.py
+++ b/spidermon/contrib/scrapy/monitors/monitors.py
@@ -459,9 +459,9 @@ class FieldCoverageMonitor(BaseScrapyMonitor):
             "SPIDERMON_FIELD_COVERAGE_RULES"
         )
         for field, expected_coverage in field_coverage_rules.items():
-            actual_coverage = self.data.stats.get(
+            actual_coverage = round(self.data.stats.get(
                 f"spidermon_field_coverage/{field}", 0
-            )
+            ),2)
             if actual_coverage < expected_coverage:
                 failures.append(
                     "{} (expected {}, got {})".format(


### PR DESCRIPTION
Sometimes the monitor raises issues if the coverage is slightly less than the desired which if rounded to 2 decimal places makes it fine. This PR fixes that issue

Example

```The following items did not meet field coverage rules:
dict/booking_link (expected 0.08, got 0.07997638758000722)
dict/domain (expected 0.62, got 0.5835189512442064)
dict/hotel_details (expected 0.01, got 0.007963674008471044)
dict/location_summary (expected 0.01, got 0.009283902565485929)
dict/opening_hours (expected 0.6, got 0.5595103926177906)
dict/phone (expected 0.84, got 0.8263806609375602)
dict/review_count_by_star (expected 0.99, got 0.6119096457086003)
dict/website (expected 0.62, got 0.5835189512442064)
```

the validation for `dict/booking_link`, `dict/hotel_details`, `dict/location_summary` and `dict/opening_hours` could be skipped as the expected is slightly less than the actual which if rounded should not raise the error.