### PR TITLE
Allow per item validators to be specified by string

### DIFF
--- a/docs/source/item-validation.rst
+++ b/docs/source/item-validation.rst
@@ -141,7 +141,7 @@ as a `dict`:
         OtherItem: '/path/to/otheritem_schema.json',
     }
 
-Keys of `dict` can also be strings matching item class names:
+Keys of ``dict`` can also be strings matching item class names:
 
 .. code-block:: python
 

--- a/docs/source/item-validation.rst
+++ b/docs/source/item-validation.rst
@@ -141,6 +141,17 @@ as a `dict`:
         OtherItem: '/path/to/otheritem_schema.json',
     }
 
+Keys of `dict` can also be strings matching item class names:
+
+.. code-block:: python
+
+    SPIDERMON_VALIDATION_SCHEMAS = {
+        'DummyItem': '/path/to/dummyitem_schema.json',
+        'OtherItem': '/path/to/otheritem_schema.json',
+    }
+
+
+
 Validation in Monitors
 ----------------------
 

--- a/spidermon/contrib/scrapy/pipelines.py
+++ b/spidermon/contrib/scrapy/pipelines.py
@@ -56,7 +56,7 @@ class ItemValidationPipeline:
             if type(schema) in (list, tuple):
                 schema = {Item: schema}
             for obj, paths in schema.items():
-                key = obj if type(obj) in (str) else obj.__name__
+                key = obj.__name__ if hasattr(obj, "__name__") else str(obj)
                 paths = paths if type(paths) in (list, tuple) else [paths]
                 objects = [loader(v) for v in paths]
                 validators[key].extend(objects)

--- a/spidermon/contrib/scrapy/pipelines.py
+++ b/spidermon/contrib/scrapy/pipelines.py
@@ -56,7 +56,7 @@ class ItemValidationPipeline:
             if type(schema) in (list, tuple):
                 schema = {Item: schema}
             for obj, paths in schema.items():
-                key = obj.__name__
+                key = obj if type(obj) in (str) else obj.__name__
                 paths = paths if type(paths) in (list, tuple) else [paths]
                 objects = [loader(v) for v in paths]
                 validators[key].extend(objects)

--- a/tests/contrib/scrapy/test_pipelines.py
+++ b/tests/contrib/scrapy/test_pipelines.py
@@ -203,6 +203,16 @@ class PipelineJSONSchemaValidator(PipelineTest):
                 assert_type_in_stats(TreeItem),
             ],
         ),
+        DataTest(
+            name="validators specified by str rather than class",
+            item=TreeItem(),
+            settings={SETTING_SCHEMAS: {"TestItem": test_schema, "TreeItem": tree_schema}},
+            cases=[
+                f"{{stats}}['{STATS_MISSINGS}'] is 1",
+                assert_type_in_stats(TestItem),
+                assert_type_in_stats(TreeItem),
+            ],
+        ),
     ]
 
 

--- a/tests/contrib/scrapy/test_pipelines.py
+++ b/tests/contrib/scrapy/test_pipelines.py
@@ -206,7 +206,9 @@ class PipelineJSONSchemaValidator(PipelineTest):
         DataTest(
             name="validators specified by str rather than class",
             item=TreeItem(),
-            settings={SETTING_SCHEMAS: {"TestItem": test_schema, "TreeItem": tree_schema}},
+            settings={
+                SETTING_SCHEMAS: {"TestItem": test_schema, "TreeItem": tree_schema}
+            },
             cases=[
                 f"{{stats}}['{STATS_MISSINGS}'] is 1",
                 assert_type_in_stats(TestItem),


### PR DESCRIPTION
We ran into a problem where another extension required our settings to be json serializable which was barfing on the class names used for specifying json schemas. I'm separately working on a fix for that extension but since under the hood the classes are just getting converted to `obj.__name__` anyway I wondered why I couldn't just specify them that way to begin with.