### PR TITLE
Fixes #422

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from scrapy.crawler import Crawler
-
+from scrapy.statscollectors import MemoryStatsCollector
 from scrapy import Spider
 
 
@@ -17,6 +17,7 @@ def get_crawler():
         settings.update(extended_settings)
         crawler = Crawler(Spider, settings=settings)
         crawler.spider = Spider("dummy")
+        crawler.stats = MemoryStatsCollector(crawler)
         return crawler
 
     return _crawler

--- a/tests/contrib/scrapy/monitors/conftest.py
+++ b/tests/contrib/scrapy/monitors/conftest.py
@@ -2,6 +2,8 @@ import pytest
 
 from scrapy import Spider
 from scrapy.crawler import Crawler
+from scrapy.statscollectors import MemoryStatsCollector
+
 from spidermon.contrib.scrapy.runners import SpiderMonitorRunner
 
 
@@ -9,6 +11,7 @@ from spidermon.contrib.scrapy.runners import SpiderMonitorRunner
 def make_data(request):
     def _make_data(settings=None):
         crawler = Crawler(Spider, settings=settings)
+        crawler.stats = MemoryStatsCollector(crawler)
         spider = Spider("dummy")
         return {
             "stats": crawler.stats.get_stats(),


### PR DESCRIPTION
**Overview**

This PR fixes the broken CI in `master`.

**Background**

The latest Scrapy versions don't have their StatsCollector (`crawler.stats`) initialized when a crawler is created. Tests that expect it to be there fail otherwise.

**Fix**

This was fixed by manually initializing `crawler.stats` the same way this was fixed in https://github.com/scrapinghub/scrapy-poet/pull/165