### PR TITLE
Fix Field names containing '_items' crash field coverage

### DIFF
--- a/spidermon/utils/field_coverage.py
+++ b/spidermon/utils/field_coverage.py
@@ -16,8 +16,8 @@ def calculate_field_coverage(stats):
 
             item_type_total = stats.get(f"spidermon_item_scraped_count/{item_type}")
 
-            if "_items" in item_key:
-                if item_key.endswith("_items"):
+            if "/_items" in item_key:
+                if item_key.endswith("/_items"):
                     continue
 
                 levels = item_key.split("/_items/")

--- a/tests/utils/test_field_coverage.py
+++ b/tests/utils/test_field_coverage.py
@@ -69,3 +69,17 @@ def test_calculate_field_coverage_from_stats_with_nested_fields():
     coverage = calculate_field_coverage(spider_stats)
 
     assert coverage == expected_coverage
+
+
+def test_calculate_field_coverage_field_ends_with_items():
+    spider_stats = {
+        "finish_reason": "finished",
+        "spidermon_item_scraped_count": 100,
+        "spidermon_item_scraped_count/dict": 100,
+        "spidermon_item_scraped_count/dict/field_ends_with_items": 100,
+    }
+
+    expected_coverage = {"spidermon_field_coverage/dict/field_ends_with_items": 1.0}
+
+    coverage = calculate_field_coverage(spider_stats)
+    assert coverage == expected_coverage


### PR DESCRIPTION
Fixes https://github.com/scrapinghub/spidermon/issues/428

It only cover the case where the fields ends with "_items" but is prefixed with something else like "count_items". 
Using only `_items` as field name is still not compatible with the coverage count. We may be able to make it work but it would require a significant rewrite of `calculate_field_coverage`