### PR TITLE
[spidermon] Fix subtract offset-naive and offset-aware

### DIFF
--- a/spidermon/contrib/scrapy/monitors/monitors.py
+++ b/spidermon/contrib/scrapy/monitors/monitors.py
@@ -489,10 +489,15 @@ class PeriodicExecutionTimeMonitor(Monitor, StatsMonitorMixin):
         max_execution_time = crawler.settings.getint(SPIDERMON_MAX_EXECUTION_TIME)
         if not max_execution_time:
             return
-        now = datetime.datetime.utcnow()
+
         start_time = self.data.stats.get("start_time")
         if not start_time:
             return
+
+        if start_time.tzinfo:
+            now = self.utc_now_with_timezone()
+        else:
+            now = datetime.datetime.utcnow()
 
         duration = now - start_time
 

--- a/spidermon/core/monitors.py
+++ b/spidermon/core/monitors.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from unittest import TestCase
+from zoneinfo import ZoneInfo
 
 from spidermon import settings
 from .options import MonitorOptions, MonitorOptionsMetaclass
@@ -100,6 +102,9 @@ class Monitor(TestCase, metaclass=MonitorOptionsMetaclass):
 
     def _init_method(self):
         MonitorOptions.add_or_create(self.method.__func__)
+
+    def utc_now_with_timezone(self):
+        return datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
 
     def __repr__(self):
         return "<MONITOR:({}) at {}>".format(self.name, hex(id(self)))

--- a/spidermon/core/monitors.py
+++ b/spidermon/core/monitors.py
@@ -1,6 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import TestCase
-from zoneinfo import ZoneInfo
 
 from spidermon import settings
 from .options import MonitorOptions, MonitorOptionsMetaclass
@@ -104,7 +103,7 @@ class Monitor(TestCase, metaclass=MonitorOptionsMetaclass):
         MonitorOptions.add_or_create(self.method.__func__)
 
     def utc_now_with_timezone(self):
-        return datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        return datetime.utcnow().replace(tzinfo=timezone.utc)
 
     def __repr__(self):
         return "<MONITOR:({}) at {}>".format(self.name, hex(id(self)))


### PR DESCRIPTION
- Add utc_now_with_timezone method in base monitor class
- Modify PeriodicExecutionTimeMonitor with the above method usage

Fixes https://github.com/scrapinghub/spidermon/issues/438