### PR TITLE
[429] Fix default templates non-subscriptable problem

### DIFF
--- a/spidermon/contrib/actions/discord/templates/discord/spider/notifier/macros.jinja
+++ b/spidermon/contrib/actions/discord/templates/discord/spider/notifier/macros.jinja
@@ -16,4 +16,4 @@
 
 {% macro render_job_url() %}{% if data.job %} / [view job in Scrapy Cloud](https://app.scrapinghub.com/p/{{ data.job.key }}){% endif %}{% endmacro %}
 {% macro render_url() %}{{ render_job_url() }}{% endmacro %}
-{% macro render_spider_name() %}{% if data.spider %}{{ data.spider.name }}{% elif data.job %}{{ data.job.metadata['spider'] }}{% else %}??{% endif %}{% endmacro %}
+{% macro render_spider_name() %}{% if data.spider %}{{ data.spider.name }}{% elif data.job %}{{ data.job.metadata.get('spider') }}{% else %}??{% endif %}{% endmacro %}

--- a/spidermon/contrib/actions/reports/templates/reports/email/monitors/result.jinja
+++ b/spidermon/contrib/actions/reports/templates/reports/email/monitors/result.jinja
@@ -133,7 +133,7 @@
                           JOB
                         ------------------------#}
                         {% if data.job %}
-                            {% set is_script = data.job.metadata['spider'].startswith('py:') %}
+                            {% set is_script = data.job.metadata.get('spider').startswith('py:') %}
                             {% set job_finished_time = data.job.metadata.get('finished_time', 0) %}
                             {% if not job_finished_time %}
                                 {% set job_finished_time = datetime.datetime.utcnow().strftime('%s')|int*1000 %}
@@ -142,10 +142,10 @@
                             {% set running_time = job_finished_time - job_running_time %}
 
                             {% if is_script %}
-                                {{ render_header_data('Script', data.job.metadata['spider'][3:], 'label label-blue') }}
+                                {{ render_header_data('Script', data.job.metadata.get('spider')[3:], 'label label-blue') }}
                             {% else %}
-                                {{ render_header_data('Spider', data.job.metadata['spider'], 'label label-blue') }}
-                                {{ render_header_data('Version', data.job.metadata['version']) }}
+                                {{ render_header_data('Spider', data.job.metadata.get('spider'), 'label label-blue') }}
+                                {{ render_header_data('Version', data.job.metadata.get('version')) }}
                                 {{ render_header_data('Items', items_count, "badge badge-green") }}
                                 {{ render_header_data('Requests', requests_count, "badge") }}
                             {% endif %}
@@ -190,11 +190,11 @@
                         {% if data.job %}
                             {{ render_header_data_separator() }}
                             {{ render_header_data('Job', data.job.key, classes='label label-blue') }}
-                            {{ render_header_data('State', data.job.metadata['state']) }}
-                            {{ render_header_data('Outcome', data.job.metadata['close_reason']) }}
-                            {{ render_header_data('Priority', data.job.metadata['priority']) }}
-                            {{ render_header_data('Bot Group', data.job.metadata['botgroup']) }}
-                            {{ render_header_data_list('Tags', data.job.metadata['tags'], 'label label-gray') }}
+                            {{ render_header_data('State', data.job.metadata.get('state')) }}
+                            {{ render_header_data('Outcome', data.job.metadata.get('close_reason')) }}
+                            {{ render_header_data('Priority', data.job.metadata.get('priority')) }}
+                            {{ render_header_data('Bot Group', data.job.metadata.get('botgroup')) }}
+                            {{ render_header_data_list('Tags', data.job.metadata.get('tags'), 'label label-gray') }}
                         {% endif %}
                     </table>
                 </td>

--- a/spidermon/contrib/actions/slack/templates/slack/spider/notifier/macros.jinja
+++ b/spidermon/contrib/actions/slack/templates/slack/spider/notifier/macros.jinja
@@ -21,4 +21,4 @@
 {% macro render_job_url() %}{% if data.job %} / <https://app.zyte.com/p/{{ data.job.key }}|view job in Scrapy Cloud>{% endif %}{% endmacro %}
 {% macro render_report_url() %}{% if include_report_link and data.meta.reports_links %} / <{{ data.meta.reports_links[report_index] }}|report>{% endif %}{% endmacro %}
 {% macro render_url() %}{{ render_report_url() }}{{ render_job_url() }}{% endmacro %}
-{% macro render_spider_name() %}{% if data.spider %}{{ data.spider.name }}{% elif data.job %}{{ data.job.metadata['spider'] }}{% else %}??{% endif %}{% endmacro %}
+{% macro render_spider_name() %}{% if data.spider %}{{ data.spider.name }}{% elif data.job %}{{ data.job.metadata.get('spider') }}{% else %}??{% endif %}{% endmacro %}

--- a/spidermon/contrib/actions/telegram/templates/telegram/spider/notifier/macros.jinja
+++ b/spidermon/contrib/actions/telegram/templates/telegram/spider/notifier/macros.jinja
@@ -16,4 +16,4 @@
 
 {% macro render_job_url() %}{% if data.job %} / [view job in Scrapy Cloud](https://app.zyte.com/p/{{ data.job.key }}){% endif %}{% endmacro %}
 {% macro render_url() %}{{ render_job_url() }}{% endmacro %}
-{% macro render_spider_name() %}{% if data.spider %}{{ data.spider.name }}{% elif data.job %}{{ data.job.metadata['spider'] }}{% else %}??{% endif %}{% endmacro %}
+{% macro render_spider_name() %}{% if data.spider %}{{ data.spider.name }}{% elif data.job %}{{ data.job.metadata.get('spider') }}{% else %}??{% endif %}{% endmacro %}

--- a/tests/contrib/actions/jobs/test_tags.py
+++ b/tests/contrib/actions/jobs/test_tags.py
@@ -44,7 +44,7 @@ def test_add_job_tags(test_settings):
     add_job_tags.data = MagicMock()
     add_job_tags.data.job.metadata = SettableDict({"tags": []})
     add_job_tags.run_action()
-    assert add_job_tags.data.job.metadata["tags"] == ["add_foo", "add_bar"]
+    assert add_job_tags.data.job.metadata.get("tags") == ["add_foo", "add_bar"]
 
 
 def test_remove_job_tags(test_settings):
@@ -58,4 +58,4 @@ def test_remove_job_tags(test_settings):
         {"tags": ["remove_foo", "remove_bar"]}
     )
     remove_job_tags.run_action()
-    assert remove_job_tags.data.job.metadata["tags"] == []
+    assert remove_job_tags.data.job.metadata.get("tags") == []


### PR DESCRIPTION
Replaces all instances of `data.job.metadata[x]` in the templates with `data.job.metadata.get(x)`.