### PR TITLE
[actions][sentry] apply fingerprint rules to group issues better

### DIFF
--- a/spidermon/contrib/actions/sentry/__init__.py
+++ b/spidermon/contrib/actions/sentry/__init__.py
@@ -136,12 +136,13 @@ class SendSentryMessage(Action):
             scope.set_extra("failed_monitors", message.get("failed_monitors", []))
 
             sentry_client.capture_event(
-                {
+                event={
                     "message": "{title} \n {description}".format(
                         title=message.get("title"),
                         description=message.get("failure_reasons", ""),
                     ),
                     "level": self.sentry_log_level,
+                    "fingerprint": [message.get("title")],
                 },
                 scope=scope,
             )


### PR DESCRIPTION
Sentry groups issues by the provided message argument in the implemented scenario. However, when the message includes a pattern recognizable by sentry defined here - https://github.com/getsentry/sentry/blob/master/src/sentry/grouping/parameterization.py#L56, values against these patterns are replaced with placeholders and aren't used to group issues.

E.g., if the sentry title contains hostnames with the same exception, the two would be grouped as below

Prashant Test Local | Development | Spider bookspider.com notification
Prashant Test Local | Development | Spider quotespider.com notification

grouped into

Prashant Test Local | Development | Spider `<hostname>` notification

This would be unintended behaviour, and we'd like to have the two spiders raise two different sentry alerts.

Providing spider's title to the fingerprint would ensure that the exact message is used to create fingerprints, and hence the two issues will have separate fingerprint values and eventually two different sentry issues.