### PR TITLE
Fix/473 process item missing spider arg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Release notes
 =============
 
+1.25.1 (unreleased)
+-------------------
+
+- bug: Fix compatibility with Scrapy 2.14+ where ``process_item`` was
+  called without the ``spider`` argument (#473).
+
 1.25.0 (2026-03-20)
 -------------------
 

--- a/spidermon/contrib/scrapy/pipelines.py
+++ b/spidermon/contrib/scrapy/pipelines.py
@@ -102,7 +102,7 @@ class ItemValidationPipeline:
             )
         return JSONSchemaValidator(schema)
 
-    def process_item(self, item, _):
+    def process_item(self, item, spider=None):
         validators = self.find_validators(item)
         if not validators:
             # No validators match this specific item type

--- a/tests/contrib/scrapy/test_pipelines.py
+++ b/tests/contrib/scrapy/test_pipelines.py
@@ -218,6 +218,18 @@ def test_validator_from_url(mocker):
     assert stats.get("spidermon/validation/validators/testitem/jsonschema", False)
 
 
+def test_process_item_without_spider_argument():
+    settings = {
+        "SPIDERMON_ENABLED": True,
+        SETTING_SCHEMAS: [test_schema],
+    }
+    test_item = TestItem({"url": "example.com"})
+    crawler = get_crawler(settings_dict=settings)
+    pipe = ItemValidationPipeline.from_crawler(crawler)
+    result = pipe.process_item(test_item)
+    assert result == test_item
+
+
 class TestAddErrors:
     def _run_pipeline(self, test_item):
         settings = {


### PR DESCRIPTION
## Summary
  - Rename `_` to `spider=None` in `process_item()` so Scrapy 2.14+ correctly detects the parameter and the method works with or without the spider argument
  - Add regression test calling `process_item()` without spider argument

  Fixes #473