### PR TITLE
Migrate SMTP action off deprecated scrapy.mail to smtplib

### DIFF
--- a/spidermon/contrib/actions/email/smtp.py
+++ b/spidermon/contrib/actions/email/smtp.py
@@ -1,4 +1,4 @@
-from scrapy.mail import MailSender
+import smtplib
 
 from spidermon.exceptions import NotConfigured
 
@@ -75,20 +75,12 @@ class SendSmtpEmail(SendEmail):
         return kwargs
 
     def send_message(self, message, **kwargs):
-        mail_sender = MailSender(
-            smtphost=self.smtp_host,
-            mailfrom=self.sender,
-            smtpuser=self.smtp_user,
-            smtppass=self.smtp_password,
-            smtpport=self.smtp_port,
-            smtptls=self.smtp_enforce_tls,
-            smtpssl=self.smtp_enforce_ssl,
-        )
+        recipients = [*self.to, *(self.cc or []), *(self.bcc or [])]
+        del message["Bcc"]
 
-        mail_sender.send(
-            to=self.to,
-            subject=message["Subject"],
-            body=message.as_string(),
-            cc=self.cc,
-            _callback=kwargs.get("_callback"),
-        )
+        smtp_cls = smtplib.SMTP_SSL if self.smtp_enforce_ssl else smtplib.SMTP
+        with smtp_cls(self.smtp_host, self.smtp_port) as smtp:
+            if self.smtp_enforce_tls:
+                smtp.starttls()
+            smtp.login(self.smtp_user, self.smtp_password)
+            smtp.sendmail(self.sender, recipients, message.as_string())

--- a/tests/contrib/actions/email/email/test_smtp_email.py
+++ b/tests/contrib/actions/email/email/test_smtp_email.py
@@ -141,6 +141,38 @@ def test_email_sent(
     assert f"Subject: {expected_subject}" in sent_message
 
 
+def test_starttls_called_when_enforce_tls(
+    mock_render_template,
+    mock_smtp,
+    smtp_action_settings,
+):
+    smtp_action_settings["SPIDERMON_SMTP_ENFORCE_TLS"] = True
+
+    crawler = get_crawler(settings_dict=smtp_action_settings)
+    send_email = SendSmtpEmail.from_crawler(crawler)
+    send_email.send_message(send_email.get_message())
+
+    mock_smtp.starttls.assert_called_once()
+
+
+def test_uses_smtp_ssl_when_enforce_ssl(
+    mock_render_template,
+    mocker,
+    smtp_action_settings,
+):
+    smtp_action_settings["SPIDERMON_SMTP_ENFORCE_SSL"] = True
+    mock_smtp_ssl_cls = mocker.patch(
+        "spidermon.contrib.actions.email.smtp.smtplib.SMTP_SSL",
+    )
+    mock_smtp_ssl = mock_smtp_ssl_cls.return_value.__enter__.return_value
+
+    crawler = get_crawler(settings_dict=smtp_action_settings)
+    send_email = SendSmtpEmail.from_crawler(crawler)
+    send_email.send_message(send_email.get_message())
+
+    mock_smtp_ssl.sendmail.assert_called_once()
+
+
 @pytest.mark.parametrize(
     "missing_setting",
     [

--- a/tests/contrib/actions/email/email/test_smtp_email.py
+++ b/tests/contrib/actions/email/email/test_smtp_email.py
@@ -12,8 +12,6 @@ from spidermon.contrib.actions.email.smtp import (
 )
 from spidermon.exceptions import NotConfigured
 
-sent_subject: list[str] = []
-
 
 @pytest.fixture
 def mock_render_template(mocker):
@@ -24,17 +22,9 @@ def mock_render_template(mocker):
 
 
 @pytest.fixture(autouse=True)
-def mock_mail_sender(mocker):
-
-    class DummyMailSender:
-        def __init__(self, *a, **kw):
-            pass
-
-        def send(self, to, subject, body, cc=None, _callback=None, **kwargs):
-            if _callback:
-                _callback(to, subject, body, cc, None, None)
-
-    mocker.patch("spidermon.contrib.actions.email.smtp.MailSender", DummyMailSender)
+def mock_smtp(mocker):
+    mock_smtp_cls = mocker.patch("spidermon.contrib.actions.email.smtp.smtplib.SMTP")
+    return mock_smtp_cls.return_value.__enter__.return_value
 
 
 @pytest.fixture
@@ -136,6 +126,7 @@ def test_set_provided_smtp_settings(setting, attribute, smtp_action_settings):
 )
 def test_email_sent(
     mock_render_template,
+    mock_smtp,
     settings_subject,
     expected_subject,
     smtp_action_settings,
@@ -144,12 +135,10 @@ def test_email_sent(
 
     crawler = get_crawler(settings_dict=smtp_action_settings)
     send_email = SendSmtpEmail.from_crawler(crawler)
-    send_email.send_message(
-        send_email.get_message(),
-        debug=True,
-        _callback=_catch_mail_sent,
-    )
-    assert sent_subject[-1] == expected_subject
+    send_email.send_message(send_email.get_message())
+
+    sent_message = mock_smtp.sendmail.call_args.args[2]
+    assert f"Subject: {expected_subject}" in sent_message
 
 
 @pytest.mark.parametrize(
@@ -170,7 +159,3 @@ def test_raise_not_configured_if_required_setting_not_provided(
     crawler = get_crawler(settings_dict=smtp_action_settings)
     with pytest.raises(NotConfigured):
         SendSmtpEmail.from_crawler(crawler)
-
-
-def _catch_mail_sent(to, subject, body, cc, attach, msg):  # noqa: PLR0913, PLR0917
-    sent_subject.append(subject)


### PR DESCRIPTION
Resolves https://github.com/scrapinghub/spidermon/issues/412, resolves https://github.com/scrapinghub/spidermon/issues/477.