### PR TITLE
Retry Slack API calls on rate-limit errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ monitoring = [
     "scrapinghub-entrypoint-scrapy>=0.11.2",
     "scrapy>=2.7.0",
     "sentry_sdk",
-    "slack_sdk",
+    "slack_sdk>=3.9.0",
 ]
 
 [tool.bumpversion]

--- a/spidermon/contrib/actions/slack/__init__.py
+++ b/spidermon/contrib/actions/slack/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
+from slack_sdk.http_retry.builtin_handlers import RateLimitErrorRetryHandler
 
 from spidermon.contrib.actions.templates import ActionWithTemplates
 from spidermon.exceptions import NotConfigured
@@ -30,6 +31,7 @@ class SlackMessageManager:
 
         self.fake = fake
         self._client = WebClient(sender_token)
+        self._client.retry_handlers.append(RateLimitErrorRetryHandler())
         self._users = None
 
     @property

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ deps =
     # contemporary with scrapy 2.7.0 so the declared floor is actually installable.
     Twisted==22.10.0
     sentry_sdk==0.1.0
-    slack_sdk==3.0.0
+    slack_sdk==3.9.0
 extras =
     monitoring
 


### PR DESCRIPTION
Resolves https://github.com/scrapinghub/spidermon/issues/207 (most of it was solved when we switched to the SDK, this is what remains)